### PR TITLE
Load homepage imagery from remote sources

### DIFF
--- a/src/assets/classroom_banner.jpeg
+++ b/src/assets/classroom_banner.jpeg
@@ -1,3 +1,0 @@
-<FILE_CONTENT>
-<USER_FILE:classroom_banner.jpeg>
-</FILE_CONTENT>

--- a/src/assets/map_of_africa.png
+++ b/src/assets/map_of_africa.png
@@ -1,3 +1,0 @@
-<FILE_CONTENT>
-<USER_FILE:Map_of_Africa.png>
-</FILE_CONTENT>

--- a/src/components/ExpansionJourney.jsx
+++ b/src/components/ExpansionJourney.jsx
@@ -1,4 +1,5 @@
-import MapImg from '@/assets/map_of_africa.png'
+const MAP_IMAGE_URL =
+  'https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/Africa_%28orthographic_projection%29.svg/1024px-Africa_%28orthographic_projection%29.svg.png'
 
 const legendItems = [
   { name: 'Pilot', color: 'bg-blue-400' },
@@ -24,7 +25,7 @@ export default function ExpansionJourney() {
           </div>
           <div className="overflow-hidden">
             <img
-              src={MapImg}
+              src={MAP_IMAGE_URL}
               alt="Map of Africa highlighting Skooli expansion journey"
               loading="lazy"
               className="w-full h-auto object-contain"

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,13 +1,15 @@
 import { Link } from 'react-router-dom'
 import { Button } from '@/components/ui/button.jsx'
-import HeroImg from '@/assets/classroom_banner.jpeg'
+
+const HERO_IMAGE_URL =
+  'https://images.unsplash.com/photo-1523580846011-d3a5bc25702b?auto=format&fit=crop&w=2400&q=80'
 
 export default function Hero() {
   return (
     <section className="relative flex min-h-[85vh] items-center justify-start overflow-hidden" id="hero">
       <div className="absolute inset-0">
         <img
-          src={HeroImg}
+          src={HERO_IMAGE_URL}
           alt="A teacher helping students in a classroom"
           className="h-full w-full object-cover object-center"
           loading="eager"


### PR DESCRIPTION
## Summary
- swap the hero banner to load the new classroom photo from a remote URL
- update the expansion journey section to render the Africa map via a remote image source
- drop the bundled banner and map assets now that the components load external imagery

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2a15ca8dc832bad4566bb1662673c