### PR TITLE
Update homepage imagery to new branding assets

### DIFF
--- a/src/components/ExpansionJourney.jsx
+++ b/src/components/ExpansionJourney.jsx
@@ -1,6 +1,4 @@
-import expansionMapSvg from '@/assets/branding/skooli-expansion-map.svg?url'
-
-const expansionMapPng = '/assets/branding/skooli-expansion-map.png'
+const expansionMapPng = '/assets/branding/skooli_african_map.png'
 
 const expansionMapFallback = `data:image/svg+xml;utf8,${encodeURIComponent(
   `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800'>
@@ -12,7 +10,7 @@ const expansionMapFallback = `data:image/svg+xml;utf8,${encodeURIComponent(
       </defs>
       <rect width='1200' height='800' fill='url(#expansionGradient)' />
       <text x='50%' y='50%' font-family='Inter, Arial, sans-serif' font-size='42' fill='#ffffff' text-anchor='middle'>
-        Upload skooli-expansion-map assets to public/assets/branding
+        Upload skooli_african_map.png to public/assets/branding
       </text>
     </svg>`
 )}`
@@ -57,7 +55,6 @@ export default function ExpansionJourney() {
           </div>
           <div className="overflow-hidden">
             <picture>
-              <source srcSet={expansionMapSvg} type="image/svg+xml" />
               <img
                 src={expansionMapPng}
                 alt="Map of Africa highlighting Skooli expansion journey"

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -2,19 +2,7 @@ import { Link } from 'react-router-dom'
 
 import { Button } from '@/components/ui/button.jsx'
 
-const heroWebpSrcSet = [
-  '/assets/branding/skooli-classroom-hero-2000.webp 2000w',
-  '/assets/branding/skooli-classroom-hero-1200.webp 1200w',
-  '/assets/branding/skooli-classroom-hero-768.webp 768w',
-].join(', ')
-
-const heroJpgSrcSet = [
-  '/assets/branding/skooli-classroom-hero-2000.jpg 2000w',
-  '/assets/branding/skooli-classroom-hero-1200.jpg 1200w',
-  '/assets/branding/skooli-classroom-hero-768.jpg 768w',
-].join(', ')
-
-const heroPrimarySrc = '/assets/branding/skooli-classroom-hero-2000.jpg'
+const heroPrimarySrc = '/assets/branding/skooli_banner_image.jpg'
 
 const heroFallback = `data:image/svg+xml;utf8,${encodeURIComponent(
   `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800'>
@@ -26,7 +14,7 @@ const heroFallback = `data:image/svg+xml;utf8,${encodeURIComponent(
       </defs>
       <rect width='1200' height='800' fill='url(#g)' />
       <text x='50%' y='50%' font-family='Inter, Arial, sans-serif' font-size='42' fill='#ffffff' text-anchor='middle'>
-        Upload skooli-classroom-hero images to public/assets/branding
+        Upload skooli_banner_image.jpg to public/assets/branding
       </text>
     </svg>`
 )}`
@@ -45,8 +33,6 @@ export default function Hero() {
     <section className="relative flex min-h-[85vh] items-center justify-start overflow-hidden" id="hero">
       <div className="absolute inset-0">
         <picture>
-          <source type="image/webp" srcSet={heroWebpSrcSet} sizes="100vw" />
-          <source type="image/jpeg" srcSet={heroJpgSrcSet} sizes="100vw" />
           <img
             src={heroPrimarySrc}
             alt="Students learning with a Skooli teacher in a bright classroom"


### PR DESCRIPTION
## Summary
- replace the hero banner with the new branding image
- update the expansion journey map to use the new African map asset and refresh its fallback copy

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_690046325a0c832ba4f4cab4ca912035