### PR TITLE
Enhance compliance kit flexibility and download cues

### DIFF
--- a/src/components/ComplianceKit.jsx
+++ b/src/components/ComplianceKit.jsx
@@ -1,7 +1,7 @@
 import { FileDown, ShieldCheck, ScrollText } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
-const documents = [
+const defaultDocuments = [
   {
     title: 'Memorandum of Understanding',
     description: 'Defines governance, rollout scope, and responsibilities for each party.',
@@ -22,7 +22,12 @@ const documents = [
   },
 ]
 
-export default function ComplianceKit({ className, title = 'Compliance kit', blurb = 'Standard templates to fast-track legal reviews and procurement approval.' }) {
+export default function ComplianceKit({
+  className,
+  title = 'Compliance kit',
+  blurb = 'Standard templates to fast-track legal reviews and procurement approval.',
+  documents = defaultDocuments,
+}) {
   return (
     <div className={cn('rounded-3xl bg-white p-6 shadow-lg shadow-black/5', className)}>
       <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">{title}</p>

--- a/src/pages/HowItWorks.jsx
+++ b/src/pages/HowItWorks.jsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import useEmblaCarousel from 'embla-carousel-react'
-import { ArrowLeft, ArrowRight, Sparkles, Route, Play, CalendarCheck } from 'lucide-react'
+import { ArrowLeft, ArrowRight, Sparkles, Route, Play, CalendarCheck, FileDown } from 'lucide-react'
 import { Button } from '@/components/ui/button.jsx'
 import ComplianceKit from '@/components/ComplianceKit.jsx'
 
@@ -306,18 +306,20 @@ export default function HowItWorks() {
               <div className="mt-6 flex flex-wrap gap-3">
                 <Button
                   asChild
-                  className="rounded-full bg-[var(--brand-emerald)] px-5 py-2 text-white hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,#000_15%)]"
+                  className="inline-flex items-center gap-2 rounded-full bg-[var(--brand-emerald)] px-5 py-2 text-white hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,#000_15%)]"
                 >
                   <a href="/templates/mou-template.pdf" download>
+                    <FileDown className="size-4" aria-hidden="true" />
                     Download MoU template
                   </a>
                 </Button>
                 <Button
                   asChild
                   variant="outline"
-                  className="rounded-full border-[var(--brand-emerald)]/40 bg-white px-5 py-2 text-[var(--brand-emerald)] hover:border-[var(--brand-emerald)]"
+                  className="inline-flex items-center gap-2 rounded-full border-[var(--brand-emerald)]/40 bg-white px-5 py-2 text-[var(--brand-emerald)] hover:border-[var(--brand-emerald)]"
                 >
                   <a href="/templates/data-sharing-template.pdf" download>
+                    <FileDown className="size-4" aria-hidden="true" />
                     Download data sharing template
                   </a>
                 </Button>


### PR DESCRIPTION
## Summary
- allow the ComplianceKit component to accept custom document sets while keeping defaults for programme pages
- add download iconography to the pilot playbook template buttons to reinforce resource availability

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_6900590ba8d8832b9a8321b0f34558f4