### PR TITLE
Update homepage hero and expansion journey images

### DIFF
--- a/src/components/ExpansionJourney.jsx
+++ b/src/components/ExpansionJourney.jsx
@@ -1,5 +1,3 @@
-import expansionMapSvg from '@/assets/branding/skooli-expansion-map.svg'
-
 const expansionMapFallback = `data:image/svg+xml;utf8,${encodeURIComponent(
   `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800'>
       <defs>
@@ -10,10 +8,12 @@ const expansionMapFallback = `data:image/svg+xml;utf8,${encodeURIComponent(
       </defs>
       <rect width='1200' height='800' fill='url(#expansionGradient)' />
       <text x='50%' y='50%' font-family='Inter, Arial, sans-serif' font-size='42' fill='#ffffff' text-anchor='middle'>
-        Upload skooli-expansion-map.svg to public/assets/branding
+        Upload skooli_african_map.png to public/assets/branding
       </text>
     </svg>`
 )}`
+
+const expansionMapSrc = '/assets/branding/skooli_african_map.png'
 
 const legendItems = [
   { name: 'Pilot districts (Uganda)', background: 'rgba(255, 215, 0, 0.85)', border: 'rgba(255,255,255,0.25)' },
@@ -75,7 +75,7 @@ export default function ExpansionJourney() {
           <div className="overflow-hidden">
             <figure className="rounded-3xl bg-white/5 p-4 shadow-xl shadow-black/20 backdrop-blur">
               <img
-                src={expansionMapSvg}
+                src={expansionMapSrc}
                 alt="Africa map with Skooli pilot, scale, and expansion countries tinted in emerald and gold"
                 loading="lazy"
                 className="h-auto w-full object-contain"

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -12,7 +12,7 @@ const heroFallback = `data:image/svg+xml;utf8,${encodeURIComponent(
       </defs>
       <rect width='1200' height='800' fill='url(#g)' />
       <text x='50%' y='50%' font-family='Inter, Arial, sans-serif' font-size='42' fill='#ffffff' text-anchor='middle'>
-        Upload skooli-classroom-hero images to public/assets/branding
+        Upload skooli_banner_image.jpg to public/assets/branding
       </text>
     </svg>`
 )}`
@@ -31,18 +31,9 @@ export default function Hero() {
     <section className="relative flex min-h-[85vh] items-center justify-start overflow-hidden" id="hero">
       <div className="absolute inset-0">
         <picture>
-          <source
-            type="image/webp"
-            srcSet="/assets/branding/skooli-classroom-hero-2000.webp 2000w, /assets/branding/skooli-classroom-hero-1200.webp 1200w, /assets/branding/skooli-classroom-hero-768.webp 768w"
-            sizes="100vw"
-          />
-          <source
-            type="image/jpeg"
-            srcSet="/assets/branding/skooli-classroom-hero-2000.jpg 2000w, /assets/branding/skooli-classroom-hero-1200.jpg 1200w, /assets/branding/skooli-classroom-hero-768.jpg 768w"
-            sizes="100vw"
-          />
+          <source type="image/jpeg" srcSet="/assets/branding/skooli_banner_image.jpg" sizes="100vw" />
           <img
-            src="/assets/branding/skooli-classroom-hero-1200.jpg"
+            src="/assets/branding/skooli_banner_image.jpg"
             alt="Skooli facilitator guiding learners in class"
             className="h-full w-full object-cover object-center"
             loading="eager"


### PR DESCRIPTION
## Summary
- swap the hero banner to use the new skooli banner image served from the public branding assets
- update the expansion journey map to reference the new African map asset and adjust the fallback messaging

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_69019f750db4832b9c4922ed4d8f96c0