### PR TITLE
Refine homepage styling for readability and balance

### DIFF
--- a/src/components/ExpansionJourney.jsx
+++ b/src/components/ExpansionJourney.jsx
@@ -54,7 +54,7 @@ export default function ExpansionJourney() {
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 items-center gap-12 lg:grid-cols-2">
           <div className="flex flex-col justify-center">
-            <p className="inline-flex w-max items-center rounded-full bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)] shadow-lg shadow-black/10 backdrop-blur">
+            <p className="inline-flex w-max items-center rounded-full border border-white/20 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white/90 shadow-lg shadow-black/10 backdrop-blur">
               Expansion journey
             </p>
             <h2 className="mt-6 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
@@ -73,7 +73,7 @@ export default function ExpansionJourney() {
             </ul>
           </div>
           <div className="overflow-hidden">
-            <figure className="rounded-3xl bg-white/5 p-4 shadow-xl shadow-black/20 backdrop-blur">
+            <figure className="mx-auto max-w-xl rounded-3xl bg-white/5 p-4 shadow-xl shadow-black/20 backdrop-blur lg:max-w-lg">
               <img
                 src={expansionMapSrc}
                 alt="Africa map with Skooli pilot, scale, and expansion countries tinted in emerald and gold"

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -32,62 +32,62 @@ const footerSections = {
 
 export default function Footer() {
   return (
-    <footer className="relative overflow-hidden text-white">
+    <footer className="relative overflow-hidden text-[color-mix(in_srgb,var(--brand-emerald)_88%,#032823_12%)]">
       <div
         className="absolute inset-0"
         style={{
-          backgroundImage: `linear-gradient(120deg, rgba(2,47,38,0.96), rgba(0,152,119,0.9)), url(${leadershipPortrait})`,
+          backgroundImage: `linear-gradient(135deg, rgba(255,255,255,0.95), rgba(252,230,174,0.88)), url(${leadershipPortrait})`,
           backgroundSize: 'cover',
           backgroundPosition: 'center',
         }}
       />
       <div
-        className="absolute inset-0 opacity-55"
+        className="absolute inset-0 opacity-70 mix-blend-luminosity"
         style={{ backgroundImage: `url(${leadershipGradient})`, backgroundSize: 'cover', backgroundPosition: 'center' }}
       />
       <div className="relative mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 gap-12 md:grid-cols-2 lg:grid-cols-4">
           <div className="space-y-6">
             <div>
-              <h2 className="text-2xl font-bold">Skooli</h2>
-              <p className="mt-4 max-w-xs text-sm text-white/80">
+              <h2 className="text-2xl font-bold text-[var(--brand-emerald)]">Skooli</h2>
+              <p className="mt-4 max-w-xs text-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
                 Education logistics built for every Ugandan learner. Ethically sourced.
                 Efficiently delivered. Faithfully stewarded.
               </p>
             </div>
-            <div className="space-y-4 text-sm text-white/80">
+            <div className="space-y-4 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
               <div className="flex items-start gap-3">
-                <MapPin className="mt-0.5 size-5 text-[var(--brand-gold)]" />
+                <MapPin className="mt-0.5 size-5 text-[var(--brand-emerald)]" />
                 <div>
-                  <p className="font-semibold">Uganda HQ</p>
+                  <p className="font-semibold text-[var(--brand-emerald)]">Uganda HQ</p>
                   <p>Plot 12, Hassim Road, Buziga</p>
                   <p>Kampala, Uganda</p>
                 </div>
               </div>
               <div className="flex items-start gap-3">
-                <MapPin className="mt-0.5 size-5 text-[var(--brand-gold)]" />
+                <MapPin className="mt-0.5 size-5 text-[var(--brand-emerald)]" />
                 <div>
-                  <p className="font-semibold">UK Office</p>
+                  <p className="font-semibold text-[var(--brand-emerald)]">UK Office</p>
                   <p>128 City Road</p>
                   <p>London, EC1V 2NX</p>
                 </div>
               </div>
               <div className="flex items-center gap-3">
-                <Mail className="size-5 text-[var(--brand-gold)]" />
-                <a className="hover:text-white" href="mailto:hello@skooli.africa">
+                <Mail className="size-5 text-[var(--brand-emerald)]" />
+                <a className="font-semibold text-[var(--brand-emerald)] transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]" href="mailto:hello@skooli.africa">
                   hello@skooli.africa
                 </a>
               </div>
               <div className="flex items-center gap-3">
-                <Phone className="size-5 text-[var(--brand-gold)]" />
-                <a className="hover:text-white" href="tel:+256414000000">
+                <Phone className="size-5 text-[var(--brand-emerald)]" />
+                <a className="font-semibold text-[var(--brand-emerald)] transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]" href="tel:+256414000000">
                   +256 414 000 000
                 </a>
               </div>
             </div>
             <div className="flex gap-3">
               <a
-                className="flex size-10 items-center justify-center rounded-full bg-white/10 transition hover:bg-[var(--brand-gold)]"
+                className="flex size-10 items-center justify-center rounded-full border border-[var(--brand-emerald)]/20 bg-white text-[var(--brand-emerald)] shadow-sm transition hover:-translate-y-0.5 hover:bg-[var(--brand-emerald)] hover:text-white"
                 href="https://www.linkedin.com/company/skooli"
                 target="_blank"
                 rel="noreferrer"
@@ -96,7 +96,7 @@ export default function Footer() {
                 <Linkedin className="size-5" />
               </a>
               <a
-                className="flex size-10 items-center justify-center rounded-full bg-white/10 transition hover:bg-[var(--brand-gold)]"
+                className="flex size-10 items-center justify-center rounded-full border border-[var(--brand-emerald)]/20 bg-white text-[var(--brand-emerald)] shadow-sm transition hover:-translate-y-0.5 hover:bg-[var(--brand-emerald)] hover:text-white"
                 href="https://twitter.com/skooli_africa"
                 target="_blank"
                 rel="noreferrer"
@@ -105,7 +105,7 @@ export default function Footer() {
                 <Twitter className="size-5" />
               </a>
               <a
-                className="flex size-10 items-center justify-center rounded-full bg-white/10 transition hover:bg-[var(--brand-gold)]"
+                className="flex size-10 items-center justify-center rounded-full border border-[var(--brand-emerald)]/20 bg-white text-[var(--brand-emerald)] shadow-sm transition hover:-translate-y-0.5 hover:bg-[var(--brand-emerald)] hover:text-white"
                 href="https://www.youtube.com/@skooli"
                 target="_blank"
                 rel="noreferrer"
@@ -117,11 +117,11 @@ export default function Footer() {
           </div>
 
           <div>
-            <h3 className="text-lg font-semibold">Company</h3>
-            <ul className="mt-6 space-y-3 text-sm text-white/80">
+            <h3 className="text-lg font-semibold text-[var(--brand-emerald)]">Company</h3>
+            <ul className="mt-6 space-y-3 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
               {footerSections.company.map((item) => (
                 <li key={item.label}>
-                  <Link className="hover:text-white" to={item.to}>
+                  <Link className="transition hover:text-[var(--brand-emerald)]" to={item.to}>
                     {item.label}
                   </Link>
                 </li>
@@ -130,11 +130,11 @@ export default function Footer() {
           </div>
 
           <div>
-            <h3 className="text-lg font-semibold">Services</h3>
-            <ul className="mt-6 space-y-3 text-sm text-white/80">
+            <h3 className="text-lg font-semibold text-[var(--brand-emerald)]">Services</h3>
+            <ul className="mt-6 space-y-3 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
               {footerSections.services.map((item) => (
                 <li key={item.label}>
-                  <Link className="hover:text-white" to={item.to}>
+                  <Link className="transition hover:text-[var(--brand-emerald)]" to={item.to}>
                     {item.label}
                   </Link>
                 </li>
@@ -143,19 +143,19 @@ export default function Footer() {
           </div>
 
           <div>
-            <h3 className="text-lg font-semibold">Resources & Legal</h3>
-            <ul className="mt-6 space-y-3 text-sm text-white/80">
+            <h3 className="text-lg font-semibold text-[var(--brand-emerald)]">Resources & Legal</h3>
+            <ul className="mt-6 space-y-3 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
               {[...footerSections.resources, ...footerSections.legal].map((item) => (
                 <li key={item.label}>
-                  <Link className="hover:text-white" to={item.to}>
+                  <Link className="transition hover:text-[var(--brand-emerald)]" to={item.to}>
                     {item.label}
                   </Link>
                 </li>
               ))}
             </ul>
-            <div className="mt-8 space-y-3 rounded-2xl bg-white/10 p-4">
-              <p className="text-sm font-semibold">Stay in the loop</p>
-              <p className="text-xs text-white/70">Monthly executive briefings on logistics, impact and technology.</p>
+            <div className="mt-8 space-y-3 rounded-2xl border border-[var(--brand-emerald)]/15 bg-[color-mix(in_srgb,var(--brand-cream)_75%,#ffffff_25%)] p-4 shadow-sm">
+              <p className="text-sm font-semibold text-[var(--brand-emerald)]">Stay in the loop</p>
+              <p className="text-xs text-[color-mix(in_srgb,var(--brand-emerald)_70%,#4c625b_30%)]">Monthly executive briefings on logistics, impact and technology.</p>
               <form
                 className="flex items-center gap-2"
                 onSubmit={(event) => {
@@ -169,7 +169,7 @@ export default function Footer() {
                 }}
               >
                 <input
-                  className="h-10 flex-1 rounded-full border border-white/30 bg-white/20 px-3 text-sm text-white placeholder:text-white/70 focus:border-[var(--brand-gold)] focus:outline-none"
+                  className="h-10 flex-1 rounded-full border border-[var(--brand-emerald)]/25 bg-white px-3 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)] placeholder:text-[color-mix(in_srgb,var(--brand-emerald)_45%,#8da49a_55%)] focus:border-[var(--brand-emerald)] focus:outline-none"
                   type="email"
                   name="email"
                   aria-label="Email for newsletter"
@@ -178,7 +178,7 @@ export default function Footer() {
                 />
                 <button
                   type="submit"
-                  className="flex h-10 items-center justify-center rounded-full bg-[var(--brand-gold)] px-3 text-sm font-semibold text-white shadow hover:bg-[color-mix(in_srgb,var(--brand-gold)_80%,#000_20%)]"
+                  className="flex h-10 items-center justify-center rounded-full bg-[var(--brand-emerald)] px-4 text-sm font-semibold text-white shadow-sm shadow-black/10 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]"
                 >
                   <Send className="size-4" />
                 </button>
@@ -186,12 +186,12 @@ export default function Footer() {
             </div>
           </div>
         </div>
-        <div className="mt-12 border-t border-white/20 pt-6">
-          <div className="flex flex-col gap-4 text-sm text-white/70 md:flex-row md:items-center md:justify-between">
+        <div className="mt-12 border-t border-[var(--brand-emerald)]/20 pt-6">
+          <div className="flex flex-col gap-4 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_72%,#032823_28%)] md:flex-row md:items-center md:justify-between">
             <p>© {new Date().getFullYear()} Skooli Technologies Group Ltd. All rights reserved.</p>
             <div className="flex items-center gap-2">
               <span>Made with</span>
-              <Heart className="size-4 text-[var(--brand-gold)]" />
+              <Heart className="size-4 text-[var(--brand-emerald)]" />
               <span>for African education</span>
             </div>
           </div>

--- a/src/components/NewsletterCTA.jsx
+++ b/src/components/NewsletterCTA.jsx
@@ -12,7 +12,9 @@ export default function NewsletterCTA() {
                 <span className="inline-flex items-center rounded-full bg-[color-mix(in_srgb,var(--brand-emerald)_10%,#ffffff_90%)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-[var(--brand-emerald)] shadow-inner shadow-white">
                   Executive Dashboard Sync
                 </span>
-                <p className="mt-4 text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Newsletter</p>
+                <p className="mt-4 inline-flex items-center gap-2 rounded-full border border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_75%,#ffffff_25%)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
+                  Newsletter
+                </p>
                 <h2 className="mt-4 text-3xl font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_88%,#032823_12%)]">
                   Executive updates delivered monthly
                 </h2>
@@ -26,17 +28,19 @@ export default function NewsletterCTA() {
             <div className="rounded-3xl border border-[var(--brand-emerald)]/15 bg-white/70 p-6">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Impact Insights</p>
+                  <p className="inline-flex items-center gap-2 rounded-full border border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_70%,#ffffff_30%)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
+                    Impact Insights
+                  </p>
                   <h3 className="mt-2 text-xl font-semibold text-[var(--brand-emerald)]">Operational highlights from the latest quarter</h3>
                 </div>
-                <span className="rounded-full bg-[color-mix(in_srgb,var(--brand-emerald)_10%,#ffffff_90%)] px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-[var(--brand-emerald)]">
+                <span className="rounded-full border border-[var(--brand-emerald)]/15 bg-[color-mix(in_srgb,var(--brand-emerald)_8%,#ffffff_92%)] px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
                   Q3 2025
                 </span>
               </div>
               <div className="mt-6 grid gap-4 sm:grid-cols-3">
                 {impactInsights.map((item) => (
-                  <div key={item.label} className="rounded-2xl border border-[var(--brand-emerald)]/20 bg-[var(--brand-cream)]/60 p-4">
-                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">{item.label}</p>
+                  <div key={item.label} className="rounded-2xl border border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_65%,#ffffff_35%)] p-4">
+                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">{item.label}</p>
                     <p className="mt-3 text-2xl font-bold text-[var(--brand-emerald)]">{item.metric}</p>
                     <p className="mt-2 text-xs text-slate-600">{item.detail}</p>
                   </div>

--- a/src/components/NewsletterSignupModule.jsx
+++ b/src/components/NewsletterSignupModule.jsx
@@ -39,7 +39,7 @@ export function NewsletterSignupModule({ layout = 'horizontal', includeDownloadL
         />
         <button
           type="submit"
-          className="flex h-12 items-center justify-center rounded-full bg-[var(--brand-emerald)] px-6 text-sm font-semibold text-white shadow-lg shadow-black/15 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]"
+          className="flex h-12 items-center justify-center rounded-full bg-[var(--brand-emerald)] px-6 text-sm font-semibold text-white shadow-lg shadow-black/15 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] whitespace-nowrap"
           disabled={status === 'loading'}
         >
           {status === 'loading' ? 'Delivering…' : status === 'success' ? 'Briefing Sent!' : 'Send briefing PDF'}

--- a/src/components/TrustedBySchools.jsx
+++ b/src/components/TrustedBySchools.jsx
@@ -15,7 +15,9 @@ export default function TrustedBySchools() {
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Trusted by schools</p>
+            <p className="inline-flex items-center gap-2 rounded-full border border-[var(--brand-emerald)]/20 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
+              Trusted by schools
+            </p>
             <h2 className="mt-4 text-3xl font-semibold text-[var(--brand-emerald)]">Serving Uganda’s most trusted institutions</h2>
           </div>
           <p className="max-w-xl text-sm text-slate-600">

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -28,10 +28,10 @@ export default function Header() {
               key={to}
               to={to}
               className={({ isActive }) =>
-                `px-4 py-2 rounded-md bg-white border border-slate-200 text-sm font-semibold transition-all duration-200 border-b-2 ${
+                `relative rounded-md border border-slate-200 bg-white px-4 py-2 text-sm font-semibold shadow-[0_6px_18px_rgba(13,37,29,0.08)] transition-all duration-200 after:absolute after:inset-x-3 after:bottom-1 after:h-1 after:rounded-full after:bg-transparent after:transition-colors after:content-[''] ${
                   isActive
-                    ? 'text-[var(--brand-emerald)] border-b-[var(--brand-gold)]'
-                    : 'text-slate-700 border-b-transparent hover:border-b-[var(--brand-gold)] hover:text-[var(--brand-emerald)]'
+                    ? 'text-[var(--brand-emerald)] ring-1 ring-[var(--brand-emerald)]/20 shadow-[0_10px_28px_rgba(5,56,44,0.12)] after:bg-[var(--brand-emerald)]'
+                    : 'text-slate-700 hover:-translate-y-0.5 hover:text-[var(--brand-emerald)] hover:shadow-[0_12px_30px_rgba(5,56,44,0.16)] hover:after:bg-[var(--brand-emerald)]/70'
                 }`
               }
             >
@@ -42,7 +42,7 @@ export default function Header() {
         <div className="hidden items-center gap-3 lg:flex">
           <Button
             variant="ghost"
-            className="rounded-md px-3 py-2 text-sm font-semibold text-[var(--brand-emerald)] hover:text-[var(--brand-gold)]"
+            className="rounded-md px-3 py-2 text-sm font-semibold text-[var(--brand-emerald)] shadow-[0_6px_18px_rgba(13,37,29,0.08)] transition-colors hover:bg-[var(--brand-emerald)] hover:text-white focus-visible:ring-[var(--brand-emerald)]"
             asChild
           >
             <Link to="/funders#investor-deck">Investor Deck</Link>


### PR DESCRIPTION
## Summary
- update navigation buttons with depth and focus styling for clearer affordances
- refresh newsletter, schools, and expansion journey sections with higher contrast accents and better spacing
- restyle the footer to use emerald typography, lighter surfaces, and consistent CTA treatments

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_6901a37415d0832b983e1413330e1d11