### PR TITLE
Apply accessible styling across all pages

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -43,7 +43,8 @@
 
 :root {
   --brand-emerald: #009877;
-  --brand-gold: #FFD700;
+  --brand-emerald-dark: #032823;
+  --brand-emerald-light: #7fd1b9;
   --brand-cream: #FCE6AE;
   --brand-white: #FFFFFF;
 
@@ -60,23 +61,23 @@
   --secondary-foreground: var(--brand-emerald);
   --muted: color-mix(in srgb, var(--brand-cream) 70%, var(--brand-white));
   --muted-foreground: #26594c;
-  --accent: var(--brand-gold);
-  --accent-foreground: var(--brand-emerald);
+  --accent: color-mix(in srgb, var(--brand-emerald) 88%, var(--brand-emerald-light) 12%);
+  --accent-foreground: var(--brand-white);
   --destructive: #c2410c;
   --border: color-mix(in srgb, var(--brand-emerald) 15%, var(--brand-white));
   --input: color-mix(in srgb, var(--brand-cream) 80%, var(--brand-white));
   --ring: color-mix(in srgb, var(--brand-emerald) 65%, #05382c);
   --chart-1: var(--brand-emerald);
-  --chart-2: var(--brand-gold);
-  --chart-3: #7fd1b9;
-  --chart-4: #f6ab3f;
-  --chart-5: #7b4c00;
+  --chart-2: color-mix(in srgb, var(--brand-emerald) 65%, var(--brand-emerald-light) 35%);
+  --chart-3: var(--brand-emerald-light);
+  --chart-4: color-mix(in srgb, var(--brand-emerald) 50%, var(--brand-emerald-light) 50%);
+  --chart-5: color-mix(in srgb, var(--brand-emerald-dark) 65%, var(--brand-emerald-light) 35%);
   --sidebar: var(--brand-white);
   --sidebar-foreground: var(--brand-emerald);
   --sidebar-primary: var(--brand-emerald);
   --sidebar-primary-foreground: var(--brand-white);
-  --sidebar-accent: var(--brand-gold);
-  --sidebar-accent-foreground: var(--brand-emerald);
+  --sidebar-accent: color-mix(in srgb, var(--brand-emerald) 80%, var(--brand-emerald-light) 20%);
+  --sidebar-accent-foreground: var(--brand-white);
   --sidebar-border: color-mix(in srgb, var(--brand-emerald) 20%, var(--brand-white));
   --sidebar-ring: color-mix(in srgb, var(--brand-emerald) 65%, #05382c);
 }
@@ -88,30 +89,30 @@
   --card-foreground: #e3fff9;
   --popover: #032823;
   --popover-foreground: #e3fff9;
-  --primary: var(--brand-gold);
-  --primary-foreground: #032823;
+  --primary: color-mix(in srgb, var(--brand-emerald) 70%, var(--brand-emerald-light) 30%);
+  --primary-foreground: #021d18;
   --secondary: #094236;
   --secondary-foreground: #e3fff9;
   --muted: #094236;
-  --muted-foreground: #7fd1b9;
-  --accent: var(--brand-gold);
-  --accent-foreground: #032823;
+  --muted-foreground: var(--brand-emerald-light);
+  --accent: color-mix(in srgb, var(--brand-emerald) 65%, var(--brand-emerald-light) 35%);
+  --accent-foreground: #021d18;
   --destructive: #f97316;
-  --border: rgba(255, 215, 0, 0.15);
-  --input: rgba(255, 215, 0, 0.2);
+  --border: color-mix(in srgb, var(--brand-emerald) 25%, transparent);
+  --input: color-mix(in srgb, var(--brand-emerald) 35%, transparent);
   --ring: rgba(0, 152, 119, 0.6);
-  --chart-1: #7fd1b9;
-  --chart-2: var(--brand-gold);
-  --chart-3: #ffd55c;
+  --chart-1: var(--brand-emerald-light);
+  --chart-2: color-mix(in srgb, var(--brand-emerald) 55%, var(--brand-emerald-light) 45%);
+  --chart-3: #a5edd5;
   --chart-4: #5ad1b0;
-  --chart-5: #ffeaae;
+  --chart-5: #b6f7e5;
   --sidebar: #032823;
   --sidebar-foreground: #e3fff9;
-  --sidebar-primary: var(--brand-gold);
-  --sidebar-primary-foreground: #032823;
-  --sidebar-accent: #0b5f4d;
-  --sidebar-accent-foreground: #e3fff9;
-  --sidebar-border: rgba(255, 215, 0, 0.12);
+  --sidebar-primary: color-mix(in srgb, var(--brand-emerald) 68%, var(--brand-emerald-light) 32%);
+  --sidebar-primary-foreground: #021d18;
+  --sidebar-accent: color-mix(in srgb, var(--brand-emerald) 55%, var(--brand-emerald-light) 45%);
+  --sidebar-accent-foreground: #021d18;
+  --sidebar-border: color-mix(in srgb, var(--brand-emerald) 20%, transparent);
   --sidebar-ring: rgba(0, 152, 119, 0.6);
 }
 
@@ -146,8 +147,8 @@ body {
 
 .btn-accent {
   @apply rounded-md shadow hover:shadow-lg transition-shadow;
-  background-color: var(--brand-gold);
-  color: var(--brand-emerald);
+  background-color: var(--accent);
+  color: var(--accent-foreground);
 }
 
 .btn-secondary {
@@ -182,7 +183,7 @@ body {
 }
 
 .icon-accent {
-  color: var(--brand-gold);
+  color: color-mix(in srgb, var(--brand-emerald) 78%, var(--brand-emerald-light) 22%);
 }
 
 /* Responsive grid */
@@ -212,17 +213,17 @@ body {
 }
 
 .nav-link:hover {
-  color: var(--brand-gold);
+  color: color-mix(in srgb, var(--brand-emerald) 82%, var(--brand-emerald-light) 18%);
 }
 
 .nav-cta {
   @apply px-4 py-2 rounded-md transition-colors font-medium;
-  background-color: var(--brand-gold);
-  color: var(--brand-emerald);
+  background-color: var(--accent);
+  color: var(--accent-foreground);
 }
 
 .nav-cta:hover {
-  background-color: color-mix(in srgb, var(--brand-gold) 80%, #000 20%);
+  background-color: color-mix(in srgb, var(--accent) 82%, var(--brand-emerald-dark) 18%);
 }
 
 .text-brand-emerald {
@@ -230,7 +231,7 @@ body {
 }
 
 .text-brand-gold {
-  color: var(--brand-gold);
+  color: var(--accent);
 }
 
 .bg-brand-emerald {
@@ -238,7 +239,7 @@ body {
 }
 
 .bg-brand-gold {
-  background-color: var(--brand-gold);
+  background-color: var(--accent);
 }
 
 .bg-brand-cream {
@@ -250,6 +251,6 @@ body {
 }
 
 .border-brand-gold {
-  border-color: var(--brand-gold);
+  border-color: var(--accent);
 }
 

--- a/src/components/AccentPill.jsx
+++ b/src/components/AccentPill.jsx
@@ -1,0 +1,52 @@
+import { cn } from '@/lib/utils.js'
+
+const toneStyles = {
+  emerald: {
+    text: 'text-[color-mix(in_srgb,var(--brand-emerald)_88%,#032823_12%)]',
+    border: 'border-[var(--brand-emerald)]/20',
+    background: 'bg-[color-mix(in_srgb,var(--brand-cream)_72%,#ffffff_28%)]',
+    shadow: 'shadow-white/60',
+  },
+  inverse: {
+    text: 'text-white',
+    border: 'border-white/30',
+    background: 'bg-white/10',
+    shadow: 'shadow-black/20',
+  },
+}
+
+const sizeStyles = {
+  xs: 'px-3 py-1 text-[10px] sm:text-xs',
+  sm: 'px-4 py-1.5 text-xs sm:text-sm',
+}
+
+export function AccentPill({
+  as: Component = 'p',
+  tone = 'emerald',
+  size = 'xs',
+  icon: Icon,
+  children,
+  className,
+  ...props
+}) {
+  const toneStyle = toneStyles[tone] ?? toneStyles.emerald
+  const sizeStyle = sizeStyles[size] ?? sizeStyles.xs
+
+  return (
+    <Component
+      className={cn(
+        'inline-flex items-center gap-2 rounded-full border font-semibold uppercase tracking-[0.3em] shadow-inner',
+        toneStyle.text,
+        toneStyle.border,
+        toneStyle.background,
+        toneStyle.shadow,
+        sizeStyle,
+        className,
+      )}
+      {...props}
+    >
+      {Icon ? <Icon className="size-3.5 sm:size-4" aria-hidden="true" /> : null}
+      {children}
+    </Component>
+  )
+}

--- a/src/components/ComplianceKit.jsx
+++ b/src/components/ComplianceKit.jsx
@@ -1,5 +1,6 @@
 import { FileDown, ShieldCheck, ScrollText } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { AccentPill } from '@/components/AccentPill.jsx'
 
 const defaultDocuments = [
   {
@@ -30,13 +31,15 @@ export default function ComplianceKit({
 }) {
   return (
     <div className={cn('rounded-3xl bg-white p-6 shadow-lg shadow-black/5', className)}>
-      <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">{title}</p>
+      <AccentPill size="sm" className="tracking-[0.25em]">
+        {title}
+      </AccentPill>
       <p className="mt-3 text-sm text-slate-600">{blurb}</p>
       <ul className="mt-6 space-y-4">
         {documents.map((document) => {
           const Icon = document.icon
           return (
-            <li key={document.title} className="flex flex-col gap-2 rounded-2xl border border-[var(--brand-emerald)]/10 bg-[var(--brand-cream)]/40 p-4 transition hover:border-[var(--brand-gold)]/40">
+            <li key={document.title} className="flex flex-col gap-2 rounded-2xl border border-[var(--brand-emerald)]/10 bg-[var(--brand-cream)]/40 p-4 transition hover:border-[color-mix(in_srgb,var(--brand-emerald)_70%,#032823_30%)]/40">
               <div className="flex items-start gap-3">
                 <span className="flex size-9 items-center justify-center rounded-full bg-[var(--brand-emerald)]/10 text-[var(--brand-emerald)]">
                   <Icon className="size-4" aria-hidden="true" />
@@ -50,7 +53,7 @@ export default function ComplianceKit({
                 <a
                   href={document.href}
                   download
-                  className="inline-flex items-center gap-2 text-xs font-semibold text-[var(--brand-gold)] hover:text-[color-mix(in_srgb,var(--brand-gold)_80%,#000_20%)]"
+                  className="inline-flex items-center gap-2 text-xs font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] underline decoration-[color-mix(in_srgb,var(--brand-emerald)_45%,#032823_55%)] decoration-2 underline-offset-4 hover:text-[var(--brand-emerald)]"
                 >
                   Download template
                   <FileDown className="size-3" aria-hidden="true" />

--- a/src/components/ExpansionJourney.jsx
+++ b/src/components/ExpansionJourney.jsx
@@ -21,6 +21,8 @@ const legendItems = [
   { name: 'Expansion markets (Ghana)', background: 'rgba(252,230,174,0.75)', border: 'rgba(255,255,255,0.4)' },
 ]
 
+import { AccentPill } from '@/components/AccentPill.jsx'
+
 const phases = [
   {
     title: 'Pilot to proof',
@@ -54,7 +56,7 @@ export default function ExpansionJourney() {
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 items-center gap-12 lg:grid-cols-2">
           <div className="flex flex-col justify-center">
-            <p className="inline-flex w-max items-center rounded-full bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)] shadow-lg shadow-black/10 backdrop-blur">
+            <p className="inline-flex w-max items-center rounded-full border border-white/20 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white/90 shadow-lg shadow-black/10 backdrop-blur">
               Expansion journey
             </p>
             <h2 className="mt-6 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
@@ -73,7 +75,7 @@ export default function ExpansionJourney() {
             </ul>
           </div>
           <div className="overflow-hidden">
-            <figure className="rounded-3xl bg-white/5 p-4 shadow-xl shadow-black/20 backdrop-blur">
+            <figure className="mx-auto max-w-xl rounded-3xl bg-white/5 p-4 shadow-xl shadow-black/20 backdrop-blur lg:max-w-lg">
               <img
                 src={expansionMapSrc}
                 alt="Africa map with Skooli pilot, scale, and expansion countries tinted in emerald and gold"
@@ -85,7 +87,9 @@ export default function ExpansionJourney() {
               <figcaption className="mt-6 space-y-4 rounded-2xl bg-white/10 p-4 text-left text-white/90">
                 {phases.map(({ title, timeline, summary }) => (
                   <div key={title}>
-                    <p className="text-sm font-semibold uppercase tracking-[0.25em] text-[var(--brand-gold)]">{timeline}</p>
+                    <AccentPill tone="inverse" size="xs" className="tracking-[0.25em]">
+                      {timeline}
+                    </AccentPill>
                     <p className="mt-1 text-lg font-semibold text-white">{title}</p>
                     <p className="mt-2 text-sm text-white/85">{summary}</p>
                   </div>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -32,62 +32,62 @@ const footerSections = {
 
 export default function Footer() {
   return (
-    <footer className="relative overflow-hidden text-white">
+    <footer className="relative overflow-hidden text-[color-mix(in_srgb,var(--brand-emerald)_88%,#032823_12%)]">
       <div
         className="absolute inset-0"
         style={{
-          backgroundImage: `linear-gradient(120deg, rgba(2,47,38,0.96), rgba(0,152,119,0.9)), url(${leadershipPortrait})`,
+          backgroundImage: `linear-gradient(135deg, rgba(255,255,255,0.95), rgba(252,230,174,0.88)), url(${leadershipPortrait})`,
           backgroundSize: 'cover',
           backgroundPosition: 'center',
         }}
       />
       <div
-        className="absolute inset-0 opacity-55"
+        className="absolute inset-0 opacity-70 mix-blend-luminosity"
         style={{ backgroundImage: `url(${leadershipGradient})`, backgroundSize: 'cover', backgroundPosition: 'center' }}
       />
       <div className="relative mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 gap-12 md:grid-cols-2 lg:grid-cols-4">
           <div className="space-y-6">
             <div>
-              <h2 className="text-2xl font-bold">Skooli</h2>
-              <p className="mt-4 max-w-xs text-sm text-white/80">
+              <h2 className="text-2xl font-bold text-[var(--brand-emerald)]">Skooli</h2>
+              <p className="mt-4 max-w-xs text-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
                 Education logistics built for every Ugandan learner. Ethically sourced.
                 Efficiently delivered. Faithfully stewarded.
               </p>
             </div>
-            <div className="space-y-4 text-sm text-white/80">
+            <div className="space-y-4 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
               <div className="flex items-start gap-3">
-                <MapPin className="mt-0.5 size-5 text-[var(--brand-gold)]" />
+                <MapPin className="mt-0.5 size-5 text-[var(--brand-emerald)]" />
                 <div>
-                  <p className="font-semibold">Uganda HQ</p>
+                  <p className="font-semibold text-[var(--brand-emerald)]">Uganda HQ</p>
                   <p>Plot 12, Hassim Road, Buziga</p>
                   <p>Kampala, Uganda</p>
                 </div>
               </div>
               <div className="flex items-start gap-3">
-                <MapPin className="mt-0.5 size-5 text-[var(--brand-gold)]" />
+                <MapPin className="mt-0.5 size-5 text-[var(--brand-emerald)]" />
                 <div>
-                  <p className="font-semibold">UK Office</p>
+                  <p className="font-semibold text-[var(--brand-emerald)]">UK Office</p>
                   <p>128 City Road</p>
                   <p>London, EC1V 2NX</p>
                 </div>
               </div>
               <div className="flex items-center gap-3">
-                <Mail className="size-5 text-[var(--brand-gold)]" />
-                <a className="hover:text-white" href="mailto:hello@skooli.africa">
+                <Mail className="size-5 text-[var(--brand-emerald)]" />
+                <a className="font-semibold text-[var(--brand-emerald)] transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]" href="mailto:hello@skooli.africa">
                   hello@skooli.africa
                 </a>
               </div>
               <div className="flex items-center gap-3">
-                <Phone className="size-5 text-[var(--brand-gold)]" />
-                <a className="hover:text-white" href="tel:+256414000000">
+                <Phone className="size-5 text-[var(--brand-emerald)]" />
+                <a className="font-semibold text-[var(--brand-emerald)] transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]" href="tel:+256414000000">
                   +256 414 000 000
                 </a>
               </div>
             </div>
             <div className="flex gap-3">
               <a
-                className="flex size-10 items-center justify-center rounded-full bg-white/10 transition hover:bg-[var(--brand-gold)]"
+                className="flex size-10 items-center justify-center rounded-full border border-[var(--brand-emerald)]/20 bg-white text-[var(--brand-emerald)] shadow-sm transition hover:-translate-y-0.5 hover:bg-[var(--brand-emerald)] hover:text-white"
                 href="https://www.linkedin.com/company/skooli"
                 target="_blank"
                 rel="noreferrer"
@@ -96,7 +96,7 @@ export default function Footer() {
                 <Linkedin className="size-5" />
               </a>
               <a
-                className="flex size-10 items-center justify-center rounded-full bg-white/10 transition hover:bg-[var(--brand-gold)]"
+                className="flex size-10 items-center justify-center rounded-full border border-[var(--brand-emerald)]/20 bg-white text-[var(--brand-emerald)] shadow-sm transition hover:-translate-y-0.5 hover:bg-[var(--brand-emerald)] hover:text-white"
                 href="https://twitter.com/skooli_africa"
                 target="_blank"
                 rel="noreferrer"
@@ -105,7 +105,7 @@ export default function Footer() {
                 <Twitter className="size-5" />
               </a>
               <a
-                className="flex size-10 items-center justify-center rounded-full bg-white/10 transition hover:bg-[var(--brand-gold)]"
+                className="flex size-10 items-center justify-center rounded-full border border-[var(--brand-emerald)]/20 bg-white text-[var(--brand-emerald)] shadow-sm transition hover:-translate-y-0.5 hover:bg-[var(--brand-emerald)] hover:text-white"
                 href="https://www.youtube.com/@skooli"
                 target="_blank"
                 rel="noreferrer"
@@ -117,11 +117,11 @@ export default function Footer() {
           </div>
 
           <div>
-            <h3 className="text-lg font-semibold">Company</h3>
-            <ul className="mt-6 space-y-3 text-sm text-white/80">
+            <h3 className="text-lg font-semibold text-[var(--brand-emerald)]">Company</h3>
+            <ul className="mt-6 space-y-3 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
               {footerSections.company.map((item) => (
                 <li key={item.label}>
-                  <Link className="hover:text-white" to={item.to}>
+                  <Link className="transition hover:text-[var(--brand-emerald)]" to={item.to}>
                     {item.label}
                   </Link>
                 </li>
@@ -130,11 +130,11 @@ export default function Footer() {
           </div>
 
           <div>
-            <h3 className="text-lg font-semibold">Services</h3>
-            <ul className="mt-6 space-y-3 text-sm text-white/80">
+            <h3 className="text-lg font-semibold text-[var(--brand-emerald)]">Services</h3>
+            <ul className="mt-6 space-y-3 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
               {footerSections.services.map((item) => (
                 <li key={item.label}>
-                  <Link className="hover:text-white" to={item.to}>
+                  <Link className="transition hover:text-[var(--brand-emerald)]" to={item.to}>
                     {item.label}
                   </Link>
                 </li>
@@ -143,19 +143,19 @@ export default function Footer() {
           </div>
 
           <div>
-            <h3 className="text-lg font-semibold">Resources & Legal</h3>
-            <ul className="mt-6 space-y-3 text-sm text-white/80">
+            <h3 className="text-lg font-semibold text-[var(--brand-emerald)]">Resources & Legal</h3>
+            <ul className="mt-6 space-y-3 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
               {[...footerSections.resources, ...footerSections.legal].map((item) => (
                 <li key={item.label}>
-                  <Link className="hover:text-white" to={item.to}>
+                  <Link className="transition hover:text-[var(--brand-emerald)]" to={item.to}>
                     {item.label}
                   </Link>
                 </li>
               ))}
             </ul>
-            <div className="mt-8 space-y-3 rounded-2xl bg-white/10 p-4">
-              <p className="text-sm font-semibold">Stay in the loop</p>
-              <p className="text-xs text-white/70">Monthly executive briefings on logistics, impact and technology.</p>
+            <div className="mt-8 space-y-3 rounded-2xl border border-[var(--brand-emerald)]/15 bg-[color-mix(in_srgb,var(--brand-cream)_75%,#ffffff_25%)] p-4 shadow-sm">
+              <p className="text-sm font-semibold text-[var(--brand-emerald)]">Stay in the loop</p>
+              <p className="text-xs text-[color-mix(in_srgb,var(--brand-emerald)_70%,#4c625b_30%)]">Monthly executive briefings on logistics, impact and technology.</p>
               <form
                 className="flex items-center gap-2"
                 onSubmit={(event) => {
@@ -169,7 +169,7 @@ export default function Footer() {
                 }}
               >
                 <input
-                  className="h-10 flex-1 rounded-full border border-white/30 bg-white/20 px-3 text-sm text-white placeholder:text-white/70 focus:border-[var(--brand-gold)] focus:outline-none"
+                  className="h-10 flex-1 rounded-full border border-[var(--brand-emerald)]/25 bg-white px-3 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)] placeholder:text-[color-mix(in_srgb,var(--brand-emerald)_45%,#8da49a_55%)] focus:border-[var(--brand-emerald)] focus:outline-none"
                   type="email"
                   name="email"
                   aria-label="Email for newsletter"
@@ -178,7 +178,7 @@ export default function Footer() {
                 />
                 <button
                   type="submit"
-                  className="flex h-10 items-center justify-center rounded-full bg-[var(--brand-gold)] px-3 text-sm font-semibold text-white shadow hover:bg-[color-mix(in_srgb,var(--brand-gold)_80%,#000_20%)]"
+                  className="flex h-10 items-center justify-center rounded-full bg-[var(--brand-emerald)] px-4 text-sm font-semibold text-white shadow-sm shadow-black/10 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]"
                 >
                   <Send className="size-4" />
                 </button>
@@ -186,12 +186,12 @@ export default function Footer() {
             </div>
           </div>
         </div>
-        <div className="mt-12 border-t border-white/20 pt-6">
-          <div className="flex flex-col gap-4 text-sm text-white/70 md:flex-row md:items-center md:justify-between">
+        <div className="mt-12 border-t border-[var(--brand-emerald)]/20 pt-6">
+          <div className="flex flex-col gap-4 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_72%,#032823_28%)] md:flex-row md:items-center md:justify-between">
             <p>© {new Date().getFullYear()} Skooli Technologies Group Ltd. All rights reserved.</p>
             <div className="flex items-center gap-2">
               <span>Made with</span>
-              <Heart className="size-4 text-[var(--brand-gold)]" />
+              <Heart className="size-4 text-[var(--brand-emerald)]" />
               <span>for African education</span>
             </div>
           </div>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 
 import { Button } from '@/components/ui/button.jsx'
+import { AccentPill } from '@/components/AccentPill.jsx'
 
 const heroFallback = `data:image/svg+xml;utf8,${encodeURIComponent(
   `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800'>
@@ -50,9 +51,9 @@ export default function Hero() {
       </div>
       <div className="relative z-10 mx-auto max-w-7xl px-4 py-24 text-left text-white sm:px-6 lg:px-8">
         <div className="max-w-2xl">
-          <p className="inline-flex items-center rounded-full bg-white/10 px-4 py-2 text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)] shadow-lg shadow-black/10 backdrop-blur">
+          <AccentPill tone="inverse" size="sm" className="bg-white/20">
             Executive briefing
-          </p>
+          </AccentPill>
           <h1 className="mt-6 text-4xl font-semibold leading-tight text-white sm:text-5xl lg:text-6xl">
             Operational assurance for national education pilots
           </h1>
@@ -62,7 +63,7 @@ export default function Hero() {
           <div className="mt-10">
             <Button
               size="lg"
-              className="rounded-md bg-[var(--brand-gold)] px-8 py-4 text-base font-semibold text-white shadow-lg shadow-black/10 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-gold)_80%,#000_20%)]"
+              className="rounded-md bg-[var(--brand-emerald)] px-8 py-4 text-base font-semibold text-white shadow-lg shadow-black/10 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]"
               asChild
             >
               <Link to="/downloads/skooli-impact-report-2025.pdf" target="_blank" rel="noreferrer noopener">

--- a/src/components/HowItWorksPreview.jsx
+++ b/src/components/HowItWorksPreview.jsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 import { ShoppingBag, Route, Gift } from 'lucide-react'
+import { AccentPill } from '@/components/AccentPill.jsx'
 
 const steps = [
   {
@@ -25,12 +26,14 @@ export default function HowItWorksPreview() {
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="flex flex-col items-start justify-between gap-8 md:flex-row md:items-end">
           <div>
-            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">How it works</p>
+            <AccentPill size="sm" className="tracking-[0.25em]">
+              How it works
+            </AccentPill>
             <h2 className="mt-4 text-3xl font-semibold text-[var(--brand-emerald)] sm:text-4xl">A frictionless supply chain from cart to classroom</h2>
           </div>
           <Link
             to="/how-it-works"
-            className="text-sm font-semibold text-[var(--brand-gold)] transition hover:text-[var(--brand-emerald)]"
+            className="text-sm font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] transition hover:text-[var(--brand-emerald)]"
           >
             Explore the full playbook →
           </Link>

--- a/src/components/ImpactSnapshot.jsx
+++ b/src/components/ImpactSnapshot.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { AccentPill } from '@/components/AccentPill.jsx'
 
 const stats = [
   { label: 'Schools Served', value: 168 },
@@ -35,9 +36,9 @@ export default function ImpactSnapshot() {
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="flex flex-col gap-8 md:flex-row md:items-center md:justify-between">
           <div>
-            <span className="inline-flex items-center rounded-full bg-white/15 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)] shadow-lg shadow-black/20 backdrop-blur">
+            <AccentPill tone="inverse" size="sm" className="bg-white/25">
               Executive Dashboard Sync
-            </span>
+            </AccentPill>
             <p className="mt-6 text-sm font-semibold uppercase tracking-[0.3em] text-white/70">Impact snapshot</p>
             <h2 className="mt-4 text-3xl font-semibold leading-tight sm:text-4xl">
               Real-time mission metrics from our executive dashboard
@@ -50,7 +51,7 @@ export default function ImpactSnapshot() {
                 href="/downloads/skooli-impact-report-2025.pdf"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center rounded-full bg-white px-5 py-3 text-sm font-semibold text-[var(--brand-emerald)] shadow-lg shadow-black/20 transition hover:-translate-y-0.5 hover:bg-[var(--brand-gold)] hover:text-[color-mix(in_srgb,#032823_80%,#ffffff_20%)]"
+                className="inline-flex items-center rounded-full bg-white px-5 py-3 text-sm font-semibold text-[var(--brand-emerald)] shadow-lg shadow-black/20 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_12%,#ffffff_88%)] hover:text-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]"
               >
                 Download the executive impact briefing (PDF)
               </a>

--- a/src/components/NewsletterCTA.jsx
+++ b/src/components/NewsletterCTA.jsx
@@ -12,7 +12,9 @@ export default function NewsletterCTA() {
                 <span className="inline-flex items-center rounded-full bg-[color-mix(in_srgb,var(--brand-emerald)_10%,#ffffff_90%)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-[var(--brand-emerald)] shadow-inner shadow-white">
                   Executive Dashboard Sync
                 </span>
-                <p className="mt-4 text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Newsletter</p>
+                <p className="mt-4 inline-flex items-center gap-2 rounded-full border border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_75%,#ffffff_25%)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
+                  Newsletter
+                </p>
                 <h2 className="mt-4 text-3xl font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_88%,#032823_12%)]">
                   Executive updates delivered monthly
                 </h2>
@@ -26,17 +28,19 @@ export default function NewsletterCTA() {
             <div className="rounded-3xl border border-[var(--brand-emerald)]/15 bg-white/70 p-6">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Impact Insights</p>
+                  <p className="inline-flex items-center gap-2 rounded-full border border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_70%,#ffffff_30%)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
+                    Impact Insights
+                  </p>
                   <h3 className="mt-2 text-xl font-semibold text-[var(--brand-emerald)]">Operational highlights from the latest quarter</h3>
                 </div>
-                <span className="rounded-full bg-[color-mix(in_srgb,var(--brand-emerald)_10%,#ffffff_90%)] px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-[var(--brand-emerald)]">
+                <span className="rounded-full border border-[var(--brand-emerald)]/15 bg-[color-mix(in_srgb,var(--brand-emerald)_8%,#ffffff_92%)] px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
                   Q3 2025
                 </span>
               </div>
               <div className="mt-6 grid gap-4 sm:grid-cols-3">
                 {impactInsights.map((item) => (
-                  <div key={item.label} className="rounded-2xl border border-[var(--brand-emerald)]/20 bg-[var(--brand-cream)]/60 p-4">
-                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">{item.label}</p>
+                  <div key={item.label} className="rounded-2xl border border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_65%,#ffffff_35%)] p-4">
+                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">{item.label}</p>
                     <p className="mt-3 text-2xl font-bold text-[var(--brand-emerald)]">{item.metric}</p>
                     <p className="mt-2 text-xs text-slate-600">{item.detail}</p>
                   </div>

--- a/src/components/NewsletterSignupModule.jsx
+++ b/src/components/NewsletterSignupModule.jsx
@@ -32,14 +32,14 @@ export function NewsletterSignupModule({ layout = 'horizontal', includeDownloadL
           value={email}
           onChange={(event) => setEmail(event.target.value)}
           placeholder="you@organisation.com"
-          className={`h-12 flex-1 rounded-full border border-[color-mix(in_srgb,var(--brand-emerald)_25%,#ffffff)] bg-white px-4 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_75%,#05382c_25%)] placeholder:text-[color-mix(in_srgb,var(--brand-emerald)_35%,#8b9f99_65%)] focus:border-[var(--brand-gold)] focus:outline-none ${
+          className={`h-12 flex-1 rounded-full border border-[color-mix(in_srgb,var(--brand-emerald)_25%,#ffffff)] bg-white px-4 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_75%,#05382c_25%)] placeholder:text-[color-mix(in_srgb,var(--brand-emerald)_35%,#8b9f99_65%)] focus:border-[var(--brand-emerald)] focus:outline-none ${
             isHorizontal ? '' : 'w-full'
           }`}
           aria-label="Email address"
         />
         <button
           type="submit"
-          className="flex h-12 items-center justify-center rounded-full bg-[var(--brand-emerald)] px-6 text-sm font-semibold text-white shadow-lg shadow-black/15 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]"
+          className="flex h-12 items-center justify-center rounded-full bg-[var(--brand-emerald)] px-6 text-sm font-semibold text-white shadow-lg shadow-black/15 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] whitespace-nowrap"
           disabled={status === 'loading'}
         >
           {status === 'loading' ? 'Delivering…' : status === 'success' ? 'Briefing Sent!' : 'Send briefing PDF'}
@@ -51,7 +51,7 @@ export function NewsletterSignupModule({ layout = 'horizontal', includeDownloadL
           href="/downloads/skooli-pitch-deck-q3-2025.pdf"
           target="_blank"
           rel="noopener noreferrer"
-          className="mt-4 inline-flex items-center text-sm font-semibold text-[var(--brand-emerald)] underline decoration-[var(--brand-gold)] decoration-2 underline-offset-4 transition hover:text-[var(--brand-gold)]"
+          className="mt-4 inline-flex items-center text-sm font-semibold text-[var(--brand-emerald)] underline decoration-[color-mix(in_srgb,var(--brand-emerald)_45%,#032823_55%)] decoration-2 underline-offset-4 transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]"
         >
           Download the board briefing packet (PDF)
         </a>

--- a/src/components/QuickGateways.jsx
+++ b/src/components/QuickGateways.jsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 import { ShieldCheck, ServerCog, BarChart3 } from 'lucide-react'
+import { AccentPill } from '@/components/AccentPill.jsx'
 
 const gateways = [
   {
@@ -28,7 +29,9 @@ export default function QuickGateways() {
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="flex flex-col items-start justify-between gap-8 md:flex-row md:items-end">
           <div>
-            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Quick gateways</p>
+            <AccentPill size="sm" className="tracking-[0.25em]">
+              Quick gateways
+            </AccentPill>
             <h2 className="mt-4 text-3xl font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_88%,#032823_12%)] sm:text-4xl">
               Enterprise-ready touchpoints for every operator
             </h2>
@@ -44,7 +47,7 @@ export default function QuickGateways() {
               <Link
                 key={title}
                 to={to}
-                className="group flex h-[220px] w-full flex-col justify-between rounded-2xl border border-[color-mix(in_srgb,var(--brand-emerald)_25%,#ffffff)] bg-white p-6 shadow-lg shadow-black/5 transition hover:-translate-y-1 hover:border-[var(--brand-gold)]/70 hover:shadow-xl"
+                className="group flex h-[220px] w-full flex-col justify-between rounded-2xl border border-[color-mix(in_srgb,var(--brand-emerald)_25%,#ffffff)] bg-white p-6 shadow-lg shadow-black/5 transition hover:-translate-y-1 hover:border-[color-mix(in_srgb,var(--brand-emerald)_70%,#032823_30%)] hover:shadow-xl"
               >
                 <div className="flex size-12 items-center justify-center rounded-2xl bg-[color-mix(in_srgb,var(--brand-emerald)_12%,#ffffff_88%)] text-[var(--brand-emerald)] shadow-md shadow-black/5 transition group-hover:bg-[var(--brand-emerald)] group-hover:text-white">
                   <IconComponent className="size-6" aria-hidden="true" />
@@ -53,7 +56,7 @@ export default function QuickGateways() {
                   <h3 className="text-lg font-semibold text-[var(--brand-emerald)]">{title}</h3>
                   <p className="mt-2 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_35%,#05382c_65%)]">{description}</p>
                 </div>
-                <span className="inline-flex items-center justify-start text-sm font-semibold text-[var(--brand-emerald)] transition group-hover:text-[var(--brand-gold)]">
+                <span className="inline-flex items-center justify-start text-sm font-semibold text-[var(--brand-emerald)] transition group-hover:text-[color-mix(in_srgb,var(--brand-emerald)_70%,#032823_30%)]">
                   Explore
                   <svg
                     className="ml-2 size-4 transition group-hover:translate-x-1"

--- a/src/components/TrustedBySchools.jsx
+++ b/src/components/TrustedBySchools.jsx
@@ -15,7 +15,9 @@ export default function TrustedBySchools() {
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Trusted by schools</p>
+            <p className="inline-flex items-center gap-2 rounded-full border border-[var(--brand-emerald)]/20 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
+              Trusted by schools
+            </p>
             <h2 className="mt-4 text-3xl font-semibold text-[var(--brand-emerald)]">Serving Uganda’s most trusted institutions</h2>
           </div>
           <p className="max-w-xl text-sm text-slate-600">

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -28,10 +28,10 @@ export default function Header() {
               key={to}
               to={to}
               className={({ isActive }) =>
-                `px-4 py-2 rounded-md bg-white border border-slate-200 text-sm font-semibold transition-all duration-200 border-b-2 ${
+                `relative rounded-md border border-slate-200 bg-white px-4 py-2 text-sm font-semibold shadow-[0_6px_18px_rgba(13,37,29,0.08)] transition-all duration-200 after:absolute after:inset-x-3 after:bottom-1 after:h-1 after:rounded-full after:bg-transparent after:transition-colors after:content-[''] ${
                   isActive
-                    ? 'text-[var(--brand-emerald)] border-b-[var(--brand-gold)]'
-                    : 'text-slate-700 border-b-transparent hover:border-b-[var(--brand-gold)] hover:text-[var(--brand-emerald)]'
+                    ? 'text-[var(--brand-emerald)] ring-1 ring-[var(--brand-emerald)]/20 shadow-[0_10px_28px_rgba(5,56,44,0.12)] after:bg-[var(--brand-emerald)]'
+                    : 'text-slate-700 hover:-translate-y-0.5 hover:text-[var(--brand-emerald)] hover:shadow-[0_12px_30px_rgba(5,56,44,0.16)] hover:after:bg-[var(--brand-emerald)]/70'
                 }`
               }
             >
@@ -42,7 +42,7 @@ export default function Header() {
         <div className="hidden items-center gap-3 lg:flex">
           <Button
             variant="ghost"
-            className="rounded-md px-3 py-2 text-sm font-semibold text-[var(--brand-emerald)] hover:text-[var(--brand-gold)]"
+            className="rounded-md px-3 py-2 text-sm font-semibold text-[var(--brand-emerald)] shadow-[0_6px_18px_rgba(13,37,29,0.08)] transition-colors hover:bg-[var(--brand-emerald)] hover:text-white focus-visible:ring-[var(--brand-emerald)]"
             asChild
           >
             <Link to="/funders#investor-deck">Investor Deck</Link>
@@ -51,7 +51,7 @@ export default function Header() {
         <button
           type="button"
           onClick={() => setOpen((prev) => !prev)}
-          className="rounded-md border border-slate-200 p-2 text-[var(--brand-emerald)] shadow-sm transition hover:border-[var(--brand-gold)] hover:text-[var(--brand-gold)] lg:hidden"
+          className="rounded-md border border-slate-200 p-2 text-[var(--brand-emerald)] shadow-sm transition hover:border-[color-mix(in_srgb,var(--brand-emerald)_70%,#032823_30%)] hover:text-[color-mix(in_srgb,var(--brand-emerald)_70%,#032823_30%)] lg:hidden"
           aria-label="Toggle navigation"
         >
           {open ? <X className="size-5" /> : <Menu className="size-5" />}
@@ -79,7 +79,7 @@ export default function Header() {
             <div className="mt-4 flex flex-col gap-2">
               <Button
                 variant="ghost"
-                className="w-full rounded-md py-2 text-sm font-semibold text-[var(--brand-emerald)] hover:text-[var(--brand-gold)]"
+                className="w-full rounded-md py-2 text-sm font-semibold text-[var(--brand-emerald)] hover:text-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]"
                 asChild
               >
                 <Link to="/funders#investor-deck" onClick={closeMenu}>

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react'
 import { MapPin, Linkedin, Twitter, Youtube } from 'lucide-react'
+import { AccentPill } from '@/components/AccentPill.jsx'
 import leadershipGradient from '@/assets/leadership-gradient.svg'
 import leadershipPortrait from '@/assets/leadership-portrait.svg'
 import pastoralIllustration from '@/assets/pastoral-support-illustration.svg'
@@ -161,7 +162,9 @@ export default function ContactPage() {
           style={{ backgroundImage: `url(${leadershipGradient})`, backgroundSize: 'cover', backgroundPosition: 'center' }}
         />
         <div className="relative mx-auto max-w-6xl px-4">
-          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Contact</p>
+          <AccentPill tone="inverse" className="bg-white/15">
+            Contact
+          </AccentPill>
           <h1 className="mt-4 text-4xl font-bold leading-tight text-white sm:text-5xl">
             We steward every enquiry with speed, dignity, and prayerful care
           </h1>
@@ -177,7 +180,9 @@ export default function ContactPage() {
             <div className="rounded-3xl bg-white p-6 shadow-lg shadow-black/5">
               <div className="flex flex-wrap items-center justify-between gap-4">
                 <h2 className="text-2xl font-semibold text-[var(--brand-emerald)]">Choose your channel</h2>
-                <p className="text-xs uppercase tracking-[0.3em] text-[var(--brand-gold)]">Average response 6 hours</p>
+                <AccentPill size="xs" className="tracking-[0.25em]">
+                  Average response 6 hours
+                </AccentPill>
               </div>
               <div className="mt-6 flex flex-wrap gap-3">
                 {segmentOrder.map((segment) => (
@@ -188,7 +193,7 @@ export default function ContactPage() {
                     className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
                       activeSegment === segment
                         ? 'bg-[var(--brand-emerald)] text-white shadow'
-                        : 'bg-[var(--brand-cream)] text-[var(--brand-emerald)] hover:bg-[var(--brand-emerald)]/10'
+                        : 'bg-[color-mix(in_srgb,var(--brand-cream)_68%,#ffffff_32%)] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] shadow-inner shadow-white/50 hover:bg-[var(--brand-emerald)]/10'
                     }`}
                   >
                     {segmentConfig[segment].label}
@@ -200,7 +205,7 @@ export default function ContactPage() {
                 {currentSegment.fields.map((field) => {
                   const fieldId = `${activeSegment}-${field.id}`
                   const baseInputClasses =
-                    'mt-1 w-full rounded-md border border-[var(--brand-emerald)]/20 bg-[var(--brand-cream)] px-4 py-3 text-sm text-slate-700 focus:border-[var(--brand-gold)] focus:outline-none'
+                    'mt-1 w-full rounded-md border border-[var(--brand-emerald)]/20 bg-[var(--brand-cream)] px-4 py-3 text-sm text-slate-700 focus:border-[var(--brand-emerald)] focus:outline-none'
 
                   if (field.type === 'select') {
                     const isSupportType = field.id === 'support_type'
@@ -280,7 +285,7 @@ export default function ContactPage() {
                 )}
                 <button
                   type="submit"
-                  className="w-full rounded-md bg-[var(--brand-gold)] py-3 text-sm font-semibold text-[var(--brand-emerald)] shadow hover:bg-[color-mix(in_srgb,var(--brand-gold)_80%,#000_20%)]"
+                  className="w-full rounded-md bg-[var(--brand-emerald)] py-3 text-sm font-semibold text-white shadow-lg shadow-[var(--brand-emerald)]/20 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]"
                   disabled={status === 'loading'}
                 >
                   {status === 'loading' ? 'Sending…' : status === 'success' ? 'Message sent!' : 'Submit enquiry'}
@@ -289,23 +294,34 @@ export default function ContactPage() {
             </div>
             <div className="space-y-6">
               <div className="rounded-3xl bg-white p-6 shadow-lg shadow-black/5">
-                <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Direct contacts</p>
+                <AccentPill size="sm" className="tracking-[0.25em]">
+                  Direct contacts
+                </AccentPill>
                 <div className="mt-4 space-y-3 text-sm text-slate-600">
                   <div>
                     <p className="font-semibold text-[var(--brand-emerald)]">Investor relations</p>
-                    <a className="text-[var(--brand-gold)]" href="mailto:invest@skooli.africa">
+                    <a
+                      className="text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] hover:text-[var(--brand-emerald)]"
+                      href="mailto:invest@skooli.africa"
+                    >
                       invest@skooli.africa
                     </a>
                   </div>
                   <div>
                     <p className="font-semibold text-[var(--brand-emerald)]">Press & media</p>
-                    <a className="text-[var(--brand-gold)]" href="mailto:pr@skooli.africa">
+                    <a
+                      className="text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] hover:text-[var(--brand-emerald)]"
+                      href="mailto:pr@skooli.africa"
+                    >
                       pr@skooli.africa
                     </a>
                   </div>
                   <div>
                     <p className="font-semibold text-[var(--brand-emerald)]">Family support</p>
-                    <a className="text-[var(--brand-gold)]" href="mailto:hello@skooli.africa">
+                    <a
+                      className="text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] hover:text-[var(--brand-emerald)]"
+                      href="mailto:hello@skooli.africa"
+                    >
                       hello@skooli.africa
                     </a>
                   </div>
@@ -321,18 +337,26 @@ export default function ContactPage() {
                       </span>
                       <div>
                         <p className="text-base font-semibold text-[var(--brand-emerald)]">{office.title}</p>
-                        <p className="text-xs uppercase tracking-[0.3em] text-[var(--brand-gold)]">{office.emphasis}</p>
+                        <AccentPill size="xs" className="mt-2 tracking-[0.25em]">
+                          {office.emphasis}
+                        </AccentPill>
                         <div className="mt-3 space-y-1 text-sm text-slate-600">
                           {office.address.map((line) => (
                             <p key={line}>{line}</p>
                           ))}
                           {office.phone && (
-                            <a className="block text-[var(--brand-gold)]" href={`tel:${office.phone.replace(/[^+\d]/g, '')}`}>
+                            <a
+                              className="block text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] hover:text-[var(--brand-emerald)]"
+                              href={`tel:${office.phone.replace(/[^+\d]/g, '')}`}
+                            >
                               {office.phone}
                             </a>
                           )}
                           {office.email && (
-                            <a className="block text-[var(--brand-gold)]" href={`mailto:${office.email}`}>
+                            <a
+                              className="block text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] hover:text-[var(--brand-emerald)]"
+                              href={`mailto:${office.email}`}
+                            >
                               {office.email}
                             </a>
                           )}
@@ -343,10 +367,12 @@ export default function ContactPage() {
                 ))}
               </div>
               <div className="rounded-3xl bg-white p-6 shadow-lg shadow-black/5">
-                <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Connect</p>
+                <AccentPill size="sm" className="tracking-[0.25em]">
+                  Connect
+                </AccentPill>
                 <div className="mt-3 flex gap-3">
                   <a
-                    className="flex size-10 items-center justify-center rounded-full bg-[var(--brand-emerald)] text-white shadow hover:bg-[var(--brand-gold)]"
+                    className="flex size-10 items-center justify-center rounded-full bg-[var(--brand-emerald)] text-white shadow hover:bg-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]"
                     href="https://www.linkedin.com/company/skooli"
                     target="_blank"
                     rel="noreferrer"
@@ -355,7 +381,7 @@ export default function ContactPage() {
                     <Linkedin className="size-5" />
                   </a>
                   <a
-                    className="flex size-10 items-center justify-center rounded-full bg-[var(--brand-emerald)] text-white shadow hover:bg-[var(--brand-gold)]"
+                    className="flex size-10 items-center justify-center rounded-full bg-[var(--brand-emerald)] text-white shadow hover:bg-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]"
                     href="https://twitter.com/skooli_africa"
                     target="_blank"
                     rel="noreferrer"
@@ -364,7 +390,7 @@ export default function ContactPage() {
                     <Twitter className="size-5" />
                   </a>
                   <a
-                    className="flex size-10 items-center justify-center rounded-full bg-[var(--brand-emerald)] text-white shadow hover:bg-[var(--brand-gold)]"
+                    className="flex size-10 items-center justify-center rounded-full bg-[var(--brand-emerald)] text-white shadow hover:bg-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]"
                     href="https://www.youtube.com/@skooli"
                     target="_blank"
                     rel="noreferrer"
@@ -404,13 +430,18 @@ export default function ContactPage() {
                 <h3 className="text-2xl font-semibold">Prayer & pastoral support</h3>
                 <p className="mt-3 text-sm text-white/85">
                   Our chaplaincy team offers scripture-grounded encouragement, trauma-informed care, and intercession for learners and staff. Submit requests via the support form or email
-                  <a className="font-semibold text-[var(--brand-gold)]" href="mailto:prayer@skooli.africa">
+                  <a
+                    className="font-semibold text-white underline decoration-white/60 decoration-2 underline-offset-4 hover:text-white"
+                    href="mailto:prayer@skooli.africa"
+                  >
                     {' '}
                     prayer@skooli.africa
                   </a>
                   .
                 </p>
-                <p className="mt-4 text-xs uppercase tracking-[0.3em] text-[var(--brand-gold)]">Live intercession line: +256 708 123 450</p>
+                <AccentPill tone="inverse" className="mt-4 bg-white/20 tracking-[0.25em]">
+                  Live intercession line: +256 708 123 450
+                </AccentPill>
               </div>
             </div>
           </div>

--- a/src/pages/ForSchools.jsx
+++ b/src/pages/ForSchools.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { ShieldCheck, Wallet, BarChart3, CalendarDays, Star, Quote, Activity, BadgeCheck, AlertTriangle } from 'lucide-react'
 import { Button } from '@/components/ui/button.jsx'
 import ComplianceKit from '@/components/ComplianceKit.jsx'
+import { AccentPill } from '@/components/AccentPill.jsx'
 
 const benefits = [
   {
@@ -65,7 +66,9 @@ export default function ForSchools() {
     <div className="bg-[var(--brand-cream)]">
       <section className="bg-white py-16">
         <div className="mx-auto max-w-6xl px-4">
-          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">For schools</p>
+          <AccentPill size="sm" className="tracking-[0.25em]">
+            For schools
+          </AccentPill>
           <div className="mt-6 grid gap-8 lg:grid-cols-[1.3fr_1fr] lg:items-center">
             <div>
               <h1 className="text-4xl font-bold text-[var(--brand-emerald)]">A reliable partner for school administrators</h1>
@@ -76,7 +79,7 @@ export default function ForSchools() {
                 <div className="flex items-center gap-2 rounded-full bg-[var(--brand-emerald)]/10 px-4 py-2 text-sm font-semibold text-[var(--brand-emerald)]">
                   <BadgeCheck className="size-4" aria-hidden="true" /> ≥30% parent adoption in first term
                 </div>
-                <div className="flex items-center gap-2 rounded-full bg-[var(--brand-gold)]/10 px-4 py-2 text-sm font-semibold text-[var(--brand-emerald)]">
+                <div className="flex items-center gap-2 rounded-full bg-[color-mix(in_srgb,var(--brand-emerald)_12%,#ffffff_88%)] px-4 py-2 text-sm font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
                   <Activity className="size-4" aria-hidden="true" /> ≥95% delivery SLA maintained
                 </div>
               </div>
@@ -124,7 +127,9 @@ export default function ForSchools() {
 
       <section className="py-16">
         <div className="mx-auto max-w-6xl px-4">
-          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Implementation timeline</p>
+          <AccentPill size="sm" className="tracking-[0.25em]">
+            Implementation timeline
+          </AccentPill>
           <div className="mt-8 overflow-hidden rounded-3xl bg-white p-8 shadow-lg shadow-black/5">
             <div className="relative">
               <div className="absolute top-1/2 h-0.5 w-full -translate-y-1/2 bg-[var(--brand-emerald)]/20" aria-hidden="true" />
@@ -148,7 +153,9 @@ export default function ForSchools() {
         <div className="mx-auto max-w-6xl px-4">
           <div className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr] lg:items-start">
             <div>
-              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Risk mitigation</p>
+              <AccentPill size="sm" className="tracking-[0.25em]">
+                Risk mitigation
+              </AccentPill>
               <h2 className="mt-4 text-3xl font-semibold text-[var(--brand-emerald)]">Controls that de-risk your procurement board</h2>
               <p className="mt-3 text-sm text-slate-600">
                 Every partnership is underpinned by proactive risk ownership—from diversified suppliers to data privacy audits—so school governors stay confident in scale decisions.
@@ -156,7 +163,7 @@ export default function ForSchools() {
               <div className="mt-6 grid gap-4 sm:grid-cols-3">
                 {riskCallouts.map((item) => (
                   <div key={item.title} className="rounded-3xl bg-white p-4 shadow-lg shadow-black/5">
-                    <AlertTriangle className="size-5 text-[var(--brand-gold)]" aria-hidden="true" />
+                    <AlertTriangle className="size-5 text-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]" aria-hidden="true" />
                     <h3 className="mt-3 text-sm font-semibold text-[var(--brand-emerald)]">{item.title}</h3>
                     <p className="mt-2 text-xs text-slate-600">{item.detail}</p>
                   </div>
@@ -181,8 +188,8 @@ export default function ForSchools() {
         <div className="mx-auto max-w-6xl px-4">
           <div className="grid gap-8 md:grid-cols-3">
             {testimonials.map((testimonial) => (
-              <div key={testimonial.name} className="rounded-3xl bg-[var(--brand-cream)] p-6 shadow-lg shadow-black/5">
-                <div className="flex items-center gap-2 text-[var(--brand-gold)]">
+              <div key={testimonial.name} className="rounded-3xl bg-[color-mix(in_srgb,var(--brand-cream)_85%,#ffffff_15%)] p-6 shadow-lg shadow-black/5">
+                <div className="flex items-center gap-2 text-[color-mix(in_srgb,var(--brand-emerald)_72%,var(--brand-emerald-light)_28%)]">
                   {[...Array(testimonial.rating)].map((_, index) => (
                     <Star key={index} className="size-4 fill-current" />
                   ))}
@@ -203,7 +210,7 @@ export default function ForSchools() {
             Book a slot with our school success team. We’ll customise the walkthrough to your context and send a follow-up proposal.
           </p>
           <Button
-            className="mt-6 rounded-md bg-[var(--brand-gold)] px-8 py-3 text-white shadow hover:bg-[color-mix(in_srgb,var(--brand-gold)_80%,#000_20%)]"
+            className="mt-6 rounded-md bg-[var(--brand-emerald)] px-8 py-3 text-white shadow-lg shadow-[var(--brand-emerald)]/20 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]"
             asChild
           >
             <a href="https://calendly.com/skooli-schools/20min-demo" target="_blank" rel="noreferrer">
@@ -248,7 +255,9 @@ function PortalLoop() {
         <div
           key={card.title}
           className={`rounded-2xl border p-4 shadow-lg shadow-black/5 transition ${
-            activeIndex === index ? 'border-[var(--brand-gold)] bg-white' : 'border-transparent bg-white/80'
+            activeIndex === index
+              ? 'border-[var(--brand-emerald)] bg-white'
+              : 'border-transparent bg-white/80'
           }`}
         >
           <h3 className="text-sm font-semibold text-[var(--brand-emerald)]">{card.title}</h3>
@@ -301,7 +310,15 @@ function RiskMitigationMatrix() {
           />
         ))}
         <g>
-          <rect x="24" y="92" width="56" height="32" rx="8" fill="var(--brand-gold)" fillOpacity="0.2" />
+          <rect
+            x="24"
+            y="92"
+            width="56"
+            height="32"
+            rx="8"
+            fill="color-mix(in srgb, var(--brand-emerald) 68%, var(--brand-emerald-light) 32%)"
+            fillOpacity="0.2"
+          />
           <text x="28" y="112" fill="var(--brand-emerald)" fontSize="10" fontWeight="600">
             Late deliveries
           </text>
@@ -319,7 +336,15 @@ function RiskMitigationMatrix() {
           </text>
         </g>
         <g>
-          <rect x="136" y="16" width="48" height="32" rx="8" fill="var(--brand-gold)" fillOpacity="0.25" />
+          <rect
+            x="136"
+            y="16"
+            width="48"
+            height="32"
+            rx="8"
+            fill="color-mix(in srgb, var(--brand-emerald) 68%, var(--brand-emerald-light) 32%)"
+            fillOpacity="0.25"
+          />
           <text x="140" y="36" fill="var(--brand-emerald)" fontSize="10" fontWeight="600">
             Fraud
           </text>

--- a/src/pages/FundersInvestors.jsx
+++ b/src/pages/FundersInvestors.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { Button } from '@/components/ui/button.jsx'
 import { FileDown, Mail, LineChart, DollarSign, ArrowRight, ExternalLink } from 'lucide-react'
+import { AccentPill } from '@/components/AccentPill.jsx'
 import logisticsBackbone from '@/assets/logistics_backbone.png'
 import routeIntelligence from '@/assets/route_intelligence.png'
 import worldEducationForum from '@/assets/world_education_forum.png'
@@ -109,7 +110,9 @@ export default function FundersInvestors() {
         <div className="mx-auto max-w-6xl px-4">
           <div className="grid items-center gap-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
             <div>
-              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Investor centre</p>
+              <AccentPill size="sm" className="tracking-[0.25em]">
+                Investor centre
+              </AccentPill>
               <h1 className="mt-4 text-4xl font-bold text-[var(--brand-emerald)]">Back Africa’s education logistics backbone</h1>
               <p className="mt-4 max-w-3xl text-base text-slate-600">
                 Skooli is raising to scale our AI-enabled supply chain, deepen school integrations, and expand to three additional East African markets by 2027.
@@ -122,7 +125,9 @@ export default function FundersInvestors() {
                   >
                     <div className="flex items-start justify-between gap-4">
                       <div>
-                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">{column.title}</p>
+                        <AccentPill size="xs" className="tracking-[0.25em]">
+                          {column.title}
+                        </AccentPill>
                         <h2 className="mt-3 text-xl font-semibold text-[var(--brand-emerald)]">{column.highlight}</h2>
                         <p className="mt-2 text-sm text-slate-600">{column.summary}</p>
                       </div>
@@ -134,10 +139,20 @@ export default function FundersInvestors() {
                       <defs>
                         <linearGradient id={`heroGradient${index}`} x1="0" x2="1" y1="1" y2="0">
                           <stop offset="0%" stopColor="var(--brand-emerald)" stopOpacity="0.15" />
-                          <stop offset="100%" stopColor="var(--brand-gold)" stopOpacity="0.4" />
+                          <stop
+                            offset="100%"
+                            stopColor="color-mix(in srgb, var(--brand-emerald) 70%, var(--brand-emerald-light) 30%)"
+                            stopOpacity="0.4"
+                          />
                         </linearGradient>
                       </defs>
-                      <path d={thesisSparklines[index].linePath} stroke="var(--brand-gold)" strokeWidth="3" fill="none" strokeLinecap="round" />
+                      <path
+                        d={thesisSparklines[index].linePath}
+                        stroke="color-mix(in srgb, var(--brand-emerald) 74%, var(--brand-emerald-light) 26%)"
+                        strokeWidth="3"
+                        fill="none"
+                        strokeLinecap="round"
+                      />
                       <path d={thesisSparklines[index].areaPath} fill={`url(#heroGradient${index})`} opacity="0.65" />
                     </svg>
                   </div>
@@ -147,7 +162,7 @@ export default function FundersInvestors() {
             <div className="relative mx-auto w-full max-w-md lg:max-w-lg">
               <div
                 aria-hidden
-                className="absolute -top-10 right-6 hidden h-64 w-64 rounded-full bg-[color-mix(in_srgb,var(--brand-gold)_18%,#ffffff_82%)] blur-3xl lg:block"
+                className="absolute -top-10 right-6 hidden h-64 w-64 rounded-full bg-[color-mix(in_srgb,var(--brand-emerald)_20%,#ffffff_80%)] blur-3xl lg:block"
               />
               <div className="relative aspect-[4/5] overflow-hidden rounded-3xl border border-[var(--brand-emerald)]/15 bg-[var(--brand-cream)] shadow-lg shadow-black/10">
                 <div
@@ -168,7 +183,9 @@ export default function FundersInvestors() {
 
       <section className="border-y border-[var(--brand-emerald)]/10 bg-[color-mix(in_srgb,var(--brand-emerald)_6%,#ffffff_94%)] py-8">
         <div className="mx-auto flex max-w-6xl flex-col gap-6 px-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="text-xs font-semibold uppercase tracking-[0.4em] text-[var(--brand-gold)]">Traction snapshot</div>
+          <AccentPill size="xs" className="tracking-[0.35em]">
+            Traction snapshot
+          </AccentPill>
           <div className="grid flex-1 gap-6 sm:grid-cols-3">
             {tractionSnapshot.map((item) => (
               <div key={item.label} className="rounded-2xl border border-[var(--brand-emerald)]/15 bg-white/60 p-4 text-center shadow-sm shadow-black/5">
@@ -195,14 +212,22 @@ export default function FundersInvestors() {
                     <div className="grid gap-4 sm:grid-cols-3">
                       {projectionData.map((item) => (
                         <div key={item.year} className="rounded-2xl bg-white p-4 text-sm text-slate-600 shadow">
-                          <p className="text-xs uppercase tracking-[0.3em] text-[var(--brand-gold)]">{item.year}</p>
+                          <AccentPill size="xs" className="tracking-[0.25em]">
+                            {item.year}
+                          </AccentPill>
                           <p className="mt-3 text-lg font-semibold text-[var(--brand-emerald)]">Revenue ${item.revenue.toFixed(1)}M</p>
                           <p className="text-sm text-emerald-600">EBITDA ${item.ebitda.toFixed(1)}M</p>
                         </div>
                       ))}
                     </div>
                     <svg viewBox="0 0 140 70" className="mt-6 h-16 w-full">
-                      <path d={sparklinePath} stroke="var(--brand-gold)" strokeWidth="3" fill="none" strokeLinecap="round" />
+                      <path
+                        d={sparklinePath}
+                        stroke="color-mix(in srgb, var(--brand-emerald) 74%, var(--brand-emerald-light) 26%)"
+                        strokeWidth="3"
+                        fill="none"
+                        strokeLinecap="round"
+                      />
                     </svg>
                   </div>
                   <div className="relative flex h-full items-center justify-center">
@@ -223,11 +248,16 @@ export default function FundersInvestors() {
               </div>
             </div>
             <div className="rounded-3xl bg-white p-6 shadow-lg shadow-black/5">
-              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Key assumptions</p>
+              <AccentPill size="sm" className="tracking-[0.25em]">
+                Key assumptions
+              </AccentPill>
               <ul className="mt-4 space-y-3 text-sm text-slate-600">
                 {projectionAssumptions.map((assumption) => (
                   <li key={assumption} className="flex items-start gap-3">
-                    <span className="mt-1 size-2 rounded-full bg-[var(--brand-gold)]" aria-hidden />
+                    <span
+                      className="mt-1 size-2 rounded-full bg-[color-mix(in_srgb,var(--brand-emerald)_72%,var(--brand-emerald-light)_28%)]"
+                      aria-hidden
+                    />
                     <span>{assumption}</span>
                   </li>
                 ))}
@@ -294,7 +324,9 @@ export default function FundersInvestors() {
               </div>
             </div>
             <div className="rounded-3xl bg-white p-6 shadow-lg shadow-black/5">
-              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Due diligence support</p>
+              <AccentPill size="sm" className="tracking-[0.25em]">
+                Due diligence support
+              </AccentPill>
               <div className="mt-4 overflow-hidden rounded-2xl border border-[var(--brand-emerald)]/15 bg-[var(--brand-cream)]/70 p-3">
                 <div
                   aria-hidden
@@ -323,7 +355,9 @@ export default function FundersInvestors() {
                   <span>Weekly investor notes summarising milestones, cash position, and risks.</span>
                 </li>
               </ul>
-              <p className="mt-6 text-xs uppercase tracking-[0.3em] text-[var(--brand-gold)]">Due diligence contact</p>
+              <AccentPill size="xs" className="mt-6 tracking-[0.25em]">
+                Due diligence contact
+              </AccentPill>
               <a className="mt-2 flex items-center gap-2 text-sm font-semibold text-[var(--brand-emerald)]" href="mailto:invest@skooli.africa">
                 <Mail className="size-4" /> invest@skooli.africa
               </a>
@@ -343,7 +377,9 @@ export default function FundersInvestors() {
         <div className="mx-auto max-w-6xl px-4">
           <div className="grid gap-8 lg:grid-cols-[1.4fr_1fr] lg:items-start">
             <div className="rounded-3xl bg-white p-6 shadow-lg shadow-black/5">
-              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Download area</p>
+              <AccentPill size="sm" className="tracking-[0.25em]">
+                Download area
+              </AccentPill>
               <p className="mt-3 text-sm text-slate-600">Enter your work email to unlock investor materials.</p>
               <form
                 className="mt-6 flex flex-col gap-3 sm:flex-row"
@@ -359,11 +395,14 @@ export default function FundersInvestors() {
                   required
                   value={email}
                   onChange={(event) => setEmail(event.target.value)}
-                  className="h-12 flex-1 rounded-md border border-[var(--brand-emerald)]/20 bg-[var(--brand-cream)] px-4 text-sm text-slate-700 placeholder:text-slate-400 focus:border-[var(--brand-gold)] focus:outline-none"
+                  className="h-12 flex-1 rounded-md border border-[var(--brand-emerald)]/20 bg-[var(--brand-cream)] px-4 text-sm text-slate-700 placeholder:text-slate-400 focus:border-[var(--brand-emerald)] focus:outline-none"
                   placeholder="you@fund.org"
                   aria-label="Work email"
                 />
-                <Button type="submit" className="h-12 rounded-md bg-[var(--brand-gold)] px-6 text-white hover:bg-[color-mix(in_srgb,var(--brand-gold)_80%,#000_20%)]">
+                <Button
+                  type="submit"
+                  className="h-12 rounded-md bg-[var(--brand-emerald)] px-6 text-white shadow-lg shadow-[var(--brand-emerald)]/20 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]"
+                >
                   Unlock files
                 </Button>
               </form>
@@ -372,7 +411,9 @@ export default function FundersInvestors() {
                   <a
                     key={link.name}
                     className={`flex items-center justify-between rounded-2xl border px-4 py-3 text-sm font-semibold transition ${
-                      unlocked ? 'border-[var(--brand-emerald)] text-[var(--brand-emerald)] hover:border-[var(--brand-gold)]' : 'border-dashed border-slate-300 text-slate-400'
+                      unlocked
+                        ? 'border-[var(--brand-emerald)] text-[var(--brand-emerald)] hover:border-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]'
+                        : 'border-dashed border-slate-300 text-slate-400'
                     }`}
                     href={unlocked ? link.href : undefined}
                     aria-disabled={!unlocked}
@@ -385,7 +426,9 @@ export default function FundersInvestors() {
               </div>
             </div>
             <div className="rounded-3xl bg-white p-6 shadow-lg shadow-black/5">
-              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Cap table</p>
+              <AccentPill size="sm" className="tracking-[0.25em]">
+                Cap table
+              </AccentPill>
               <div className="mt-4 grid gap-4">
                 {capTable.map((slice) => (
                   <div key={slice.label} className="flex items-center justify-between rounded-2xl bg-[var(--brand-cream)] p-4 text-sm text-slate-600">
@@ -394,7 +437,9 @@ export default function FundersInvestors() {
                   </div>
                 ))}
               </div>
-              <p className="mt-6 text-xs uppercase tracking-[0.3em] text-[var(--brand-gold)]">Due diligence contact</p>
+              <AccentPill size="xs" className="mt-6 tracking-[0.25em]">
+                Due diligence contact
+              </AccentPill>
               <div className="mt-3 overflow-hidden rounded-2xl border border-[var(--brand-emerald)]/15 bg-[var(--brand-cream)]/70 p-3">
                 <div
                   aria-hidden
@@ -430,7 +475,7 @@ export default function FundersInvestors() {
             Unlock the downloads above or request a personal walkthrough with our founders.
           </p>
           <Button
-            className="mt-6 rounded-md bg-[var(--brand-gold)] px-6 py-3 text-white shadow hover:bg-[color-mix(in_srgb,var(--brand-gold)_80%,#000_20%)]"
+            className="mt-6 rounded-md bg-[var(--brand-emerald)] px-6 py-3 text-white shadow-lg shadow-[var(--brand-emerald)]/20 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]"
             asChild
           >
             <a href="mailto:invest@skooli.africa?subject=Investor%20Deck%20Request">Request briefing</a>

--- a/src/pages/HowItWorks.jsx
+++ b/src/pages/HowItWorks.jsx
@@ -3,6 +3,7 @@ import useEmblaCarousel from 'embla-carousel-react'
 import { ArrowLeft, ArrowRight, Sparkles, Route, Play, CalendarCheck, FileDown } from 'lucide-react'
 import { Button } from '@/components/ui/button.jsx'
 import ComplianceKit from '@/components/ComplianceKit.jsx'
+import { AccentPill } from '@/components/AccentPill.jsx'
 
 const carouselSlides = [
   {
@@ -13,7 +14,7 @@ const carouselSlides = [
   {
     title: 'Local supplier marketplace',
     description: 'Verified Ugandan SMEs showcase stationery, uniforms, and health products.',
-    color: 'from-[color-mix(in_srgb,var(--brand-gold)_22%,white)] to-white',
+    color: 'from-[color-mix(in_srgb,var(--brand-emerald)_18%,white)] to-white',
   },
   {
     title: 'Real-time availability',
@@ -210,7 +211,11 @@ export default function HowItWorks() {
                     {carouselSlides.map((slide, index) => (
                       <span
                         key={slide.title}
-                        className={`h-2 w-6 rounded-full ${index === activeSlide ? 'bg-[var(--brand-gold)]' : 'bg-slate-300'}`}
+                        className={`h-2 w-6 rounded-full ${
+                          index === activeSlide
+                            ? 'bg-[color-mix(in_srgb,var(--brand-emerald)_76%,var(--brand-emerald-light)_24%)]'
+                            : 'bg-slate-300'
+                        }`}
                       />
                     ))}
                   </div>
@@ -225,10 +230,9 @@ export default function HowItWorks() {
               </div>
             </div>
             <div className="rounded-2xl bg-[var(--brand-cream)] p-8 shadow-lg shadow-black/5">
-              <div className="flex items-center gap-3 text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">
-                <Sparkles className="size-5" />
+              <AccentPill size="sm" icon={Sparkles} className="tracking-[0.25em]">
                 Assisted shopping
-              </div>
+              </AccentPill>
               <p className="mt-4 text-sm text-slate-600">
                 Community agents guide parents at churches and SACCO halls using tablets connected to the same catalogue.
               </p>
@@ -252,7 +256,8 @@ export default function HowItWorks() {
                 Our AI-driven routing engine optimises loading from Kampala and Gulu warehouses. Each delivery vehicle carries IoT trackers that feed into the control tower dashboard.
               </p>
               <div className="mt-6 flex items-center gap-3 rounded-full bg-white px-4 py-2 text-sm font-semibold text-[var(--brand-emerald)] shadow">
-                <Route className="size-4" /> SLA badge: <span className="text-[var(--brand-gold)]">95% on-time</span>
+                <Route className="size-4" /> SLA badge:{' '}
+                <span className="text-[color-mix(in_srgb,var(--brand-emerald)_76%,var(--brand-emerald-light)_24%)]">95% on-time</span>
               </div>
               <p className="mt-4 text-sm text-slate-600">
                 Dispatchers adjust for weather, traffic, and school calendars. Automated SMS alerts inform schools 30 minutes before arrival.
@@ -297,7 +302,9 @@ export default function HowItWorks() {
         <div className="mx-auto max-w-6xl px-4">
           <div className="grid gap-10 lg:grid-cols-[1.2fr_1fr] lg:items-start">
             <div>
-              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Pilot launch playbook</p>
+              <AccentPill size="sm" className="tracking-[0.25em]">
+                Pilot launch playbook
+              </AccentPill>
               <h2 className="mt-4 text-3xl font-semibold text-[var(--brand-emerald)]">Eight-week glide path to operational readiness</h2>
               <p className="mt-3 text-sm text-slate-600">
                 Follow a structured onboarding cadence that keeps administrators, parents, and suppliers aligned from the first
@@ -350,7 +357,9 @@ export default function HowItWorks() {
 
       <section className="py-16">
         <div className="mx-auto max-w-6xl px-4">
-          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">School cycle bundles</p>
+          <AccentPill size="sm" className="tracking-[0.25em]">
+            School cycle bundles
+          </AccentPill>
           <h2 className="mt-4 text-3xl font-semibold text-[var(--brand-emerald)]">Packages tuned to the academic calendar</h2>
           <p className="mt-2 max-w-2xl text-sm text-slate-600">
             Choose from pre-approved bundles or co-create with our merchandising team. Each accordion reveals what’s inside and the impact it unlocks.
@@ -389,10 +398,19 @@ export default function HowItWorks() {
         <div className="mx-auto max-w-6xl px-4">
           <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
             <div className="md:w-1/3">
-              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">FAQ</p>
+              <AccentPill size="sm" className="tracking-[0.25em]">
+                FAQ
+              </AccentPill>
               <h2 className="mt-4 text-3xl font-semibold text-[var(--brand-emerald)]">Answers for families, schools, and donors</h2>
               <p className="mt-4 text-sm text-slate-600">
-                Need something more specific? Reach us via <a href="mailto:hello@skooli.africa" className="font-semibold text-[var(--brand-gold)]">hello@skooli.africa</a>.
+                Need something more specific? Reach us via{' '}
+                <a
+                  href="mailto:hello@skooli.africa"
+                  className="font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] underline decoration-[color-mix(in_srgb,var(--brand-emerald)_40%,#032823_60%)] decoration-2 underline-offset-4 hover:text-[var(--brand-emerald)]"
+                >
+                  hello@skooli.africa
+                </a>
+                .
               </p>
             </div>
             <div className="md:w-2/3">
@@ -443,9 +461,17 @@ function AnimatedRouteMap() {
       <rect x="0" y="0" width="360" height="220" rx="24" fill="var(--brand-cream)" />
       <path d="M90 180 L120 120 L170 150 L220 90 L280 110" stroke="var(--brand-emerald)" strokeWidth="6" strokeLinecap="round" fill="none" strokeDasharray="1" strokeDashoffset={dashOffset} />
       <circle cx="90" cy="180" r="12" fill="var(--brand-emerald)" />
-      <circle cx="280" cy="110" r="12" fill="var(--brand-gold)" />
+      <circle cx="280" cy="110" r="12" fill="color-mix(in srgb, var(--brand-emerald) 76%, var(--brand-emerald-light) 24%)" />
       <text x="70" y="205" fill="var(--brand-emerald)" fontSize="12" fontWeight="600">Kampala Hub</text>
-      <text x="250" y="100" fill="var(--brand-gold)" fontSize="12" fontWeight="600">Gulu Cluster</text>
+      <text
+        x="250"
+        y="100"
+        fill="color-mix(in srgb, var(--brand-emerald) 76%, var(--brand-emerald-light) 24%)"
+        fontSize="12"
+        fontWeight="600"
+      >
+        Gulu Cluster
+      </text>
       <text x="130" y="70" fill="var(--brand-emerald)" fontSize="11">Dynamic rerouting</text>
       <text x="200" y="190" fill="var(--brand-emerald)" fontSize="11">Cold-chain ready</text>
     </svg>
@@ -465,7 +491,11 @@ function OperationalReadinessChecklist() {
       <defs>
         <linearGradient id="readinessGradient" x1="0%" y1="0%" x2="100%" y2="100%">
           <stop offset="0%" stopColor="var(--brand-emerald)" stopOpacity="0.1" />
-          <stop offset="100%" stopColor="var(--brand-gold)" stopOpacity="0.2" />
+          <stop
+            offset="100%"
+            stopColor="color-mix(in srgb, var(--brand-emerald) 68%, var(--brand-emerald-light) 32%)"
+            stopOpacity="0.2"
+          />
         </linearGradient>
       </defs>
       <rect x="0" y="0" width="360" height="360" rx="32" fill="url(#readinessGradient)" />
@@ -483,7 +513,7 @@ function OperationalReadinessChecklist() {
         <path
           d="M60 24 A36 36 0 1 1 59.9 24"
           fill="none"
-          stroke="var(--brand-gold)"
+          stroke="color-mix(in srgb, var(--brand-emerald) 70%, var(--brand-emerald-light) 30%)"
           strokeWidth="6"
           strokeLinecap="round"
         />
@@ -503,7 +533,13 @@ function ChecklistRow({ index, title, detail, y }) {
   return (
     <g transform={`translate(0 ${y})`}>
       <rect x="0" y="0" width="180" height="72" rx="18" fill="white" stroke="var(--brand-emerald)" strokeWidth="1" />
-      <text x="16" y="28" fill="var(--brand-gold)" fontSize="18" fontWeight="700">
+      <text
+        x="16"
+        y="28"
+        fill="color-mix(in srgb, var(--brand-emerald) 76%, var(--brand-emerald-light) 24%)"
+        fontSize="18"
+        fontWeight="700"
+      >
         {index}
       </text>
       <text x="16" y="48" fill="var(--brand-emerald)" fontSize="16" fontWeight="700">

--- a/src/pages/LegalEthics.jsx
+++ b/src/pages/LegalEthics.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { ShieldCheck, BookOpen, HeartHandshake, Download } from 'lucide-react'
+import { AccentPill } from '@/components/AccentPill.jsx'
 
 const compliancePacks = [
   {
@@ -61,7 +62,9 @@ export default function LegalEthics() {
     <div className="bg-[var(--brand-cream)]">
       <section className="bg-white py-16">
         <div className="mx-auto max-w-6xl px-4 text-center">
-          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Legal & ethics</p>
+          <AccentPill size="sm" className="tracking-[0.25em]">
+            Legal & ethics
+          </AccentPill>
           <h1 className="mt-4 text-4xl font-bold text-[var(--brand-emerald)]">Our commitments to privacy, trust, and faith</h1>
           <p className="mt-4 text-base text-slate-600">
             Skooli protects family data, honours Ugandan and UK regulations, and operates with a Christ-centered ethic.
@@ -81,7 +84,16 @@ export default function LegalEthics() {
             </p>
             <ul className="mt-4 space-y-2 text-sm text-slate-600">
               <li>• Data is encrypted, stored in EU and Ugandan data centres, and retained for seven years.</li>
-              <li>• Parents can request deletion or correction via <a className="font-semibold text-[var(--brand-gold)]" href="mailto:privacy@skooli.africa">privacy@skooli.africa</a>.</li>
+              <li>
+                • Parents can request deletion or correction via{' '}
+                <a
+                  className="font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] underline decoration-[color-mix(in_srgb,var(--brand-emerald)_45%,#032823_55%)] decoration-2 underline-offset-4 hover:text-[var(--brand-emerald)]"
+                  href="mailto:privacy@skooli.africa"
+                >
+                  privacy@skooli.africa
+                </a>
+                .
+              </li>
               <li>• Student data is never sold or shared outside approved ministries and donors bound by agreements.</li>
             </ul>
           </div>
@@ -138,7 +150,7 @@ export default function LegalEthics() {
                     </div>
                     <div className="mt-5 flex items-center justify-between text-xs font-semibold text-[var(--brand-emerald)] group-hover:text-white">
                       <span>{pack.size}</span>
-                      <span className="inline-flex items-center gap-1 rounded-full bg-white/40 px-3 py-1 text-[10px] uppercase tracking-[0.3em] text-[var(--brand-emerald)] group-hover:bg-[var(--brand-gold)] group-hover:text-[var(--brand-emerald)]">
+                      <span className="inline-flex items-center gap-1 rounded-full bg-white/40 px-3 py-1 text-[10px] uppercase tracking-[0.3em] text-[var(--brand-emerald)] group-hover:bg-white group-hover:text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
                         <Download className="size-3" /> PDF
                       </span>
                     </div>
@@ -168,7 +180,9 @@ export default function LegalEthics() {
                   type="button"
                   onClick={() => setAnalyticsCookies((prev) => !prev)}
                   className={`flex items-center rounded-full border px-4 py-1 text-xs font-semibold transition ${
-                    analyticsCookies ? 'border-[var(--brand-gold)] bg-[var(--brand-gold)] text-white' : 'border-[var(--brand-emerald)] text-[var(--brand-emerald)]'
+                    analyticsCookies
+                      ? 'border-[var(--brand-emerald)] bg-[color-mix(in_srgb,var(--brand-emerald)_88%,#032823_12%)] text-white shadow'
+                      : 'border-[var(--brand-emerald)] bg-white text-[var(--brand-emerald)]'
                   }`}
                 >
                   {analyticsCookies ? 'Enabled' : 'Disabled'}
@@ -176,7 +190,14 @@ export default function LegalEthics() {
               </div>
             </div>
             <p className="mt-4 text-xs text-slate-500">
-              Preferences are stored locally on your device. Change them anytime or email <a className="font-semibold text-[var(--brand-gold)]" href="mailto:privacy@skooli.africa">privacy@skooli.africa</a>.
+              Preferences are stored locally on your device. Change them anytime or email{' '}
+              <a
+                className="font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] underline decoration-[color-mix(in_srgb,var(--brand-emerald)_45%,#032823_55%)] decoration-2 underline-offset-4 hover:text-[var(--brand-emerald)]"
+                href="mailto:privacy@skooli.africa"
+              >
+                privacy@skooli.africa
+              </a>
+              .
             </p>
           </div>
         </div>
@@ -184,7 +205,9 @@ export default function LegalEthics() {
 
       {cookieBannerVisible && (
         <div className="fixed bottom-6 left-1/2 z-40 w-[min(90%,32rem)] -translate-x-1/2 rounded-3xl bg-[var(--brand-emerald)]/95 p-6 text-white shadow-2xl shadow-black/30 ring-1 ring-white/20">
-          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Cookies & stewardship</p>
+          <AccentPill tone="inverse" className="bg-white/20 tracking-[0.25em]">
+            Cookies & stewardship
+          </AccentPill>
           <p className="mt-3 text-sm text-white/90">
             We use essential cookies to run Skooli and analytics cookies to understand how leaders engage with our resources. Accept all or customise your preferences.
           </p>
@@ -192,7 +215,7 @@ export default function LegalEthics() {
             <button
               type="button"
               onClick={handleAcceptAll}
-              className="inline-flex flex-1 items-center justify-center rounded-full bg-[var(--brand-gold)] px-5 py-2 text-sm font-semibold text-[var(--brand-emerald)] shadow transition hover:bg-[color-mix(in_srgb,var(--brand-gold)_80%,#000_20%)]"
+              className="inline-flex flex-1 items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-[var(--brand-emerald)] shadow transition hover:bg-white/90"
             >
               Accept all cookies
             </button>

--- a/src/pages/MeetTheTeam.jsx
+++ b/src/pages/MeetTheTeam.jsx
@@ -1,4 +1,5 @@
 import { Linkedin } from 'lucide-react'
+import { AccentPill } from '@/components/AccentPill.jsx'
 
 const founders = [
   {
@@ -83,7 +84,9 @@ export default function MeetTheTeam() {
     <div className="bg-[var(--brand-cream)]">
       <section className="bg-white py-16">
         <div className="mx-auto max-w-6xl px-4 text-center">
-          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Meet the team</p>
+          <AccentPill size="sm" className="mx-auto tracking-[0.25em]">
+            Meet the team
+          </AccentPill>
           <h1 className="mt-4 text-4xl font-bold text-[var(--brand-emerald)]">Faithful leaders stewarding Skooli’s mission</h1>
           <p className="mt-4 text-base text-slate-600">
             Our team blends logistics, technology, and ministry experience to deliver for learners across Uganda.
@@ -109,9 +112,9 @@ export default function MeetTheTeam() {
                 <div className="flex flex-1 flex-col p-6">
                   <div>
                     <h3 className="text-xl font-semibold text-[var(--brand-emerald)]">{founder.name}</h3>
-                    <p className="text-sm font-semibold uppercase tracking-[0.2em] text-[var(--brand-gold)]">
+                    <AccentPill size="xs" className="mt-2 tracking-[0.2em]">
                       {founder.role}
-                    </p>
+                    </AccentPill>
                     <p className="mt-3 text-sm text-slate-600">{founder.bio}</p>
                   </div>
                   <dl className="mt-4 grid gap-3 rounded-2xl bg-[var(--brand-cream)]/70 p-4 text-sm text-[var(--brand-emerald)]">
@@ -146,7 +149,9 @@ export default function MeetTheTeam() {
             {advisors.map((advisor) => (
               <div key={advisor.name} className="rounded-3xl bg-[var(--brand-cream)] p-6 shadow-lg shadow-black/5">
                 <h3 className="text-lg font-semibold text-[var(--brand-emerald)]">{advisor.name}</h3>
-                <p className="text-sm font-semibold text-[var(--brand-gold)]">{advisor.focus}</p>
+                <AccentPill size="xs" className="mt-2 tracking-[0.2em]">
+                  {advisor.focus}
+                </AccentPill>
                 <p className="mt-3 text-sm text-slate-600">{advisor.summary}</p>
                 <div className="mt-4 flex flex-wrap gap-2">
                   {advisor.tags.map((tag) => (

--- a/src/pages/NewsUpdates.jsx
+++ b/src/pages/NewsUpdates.jsx
@@ -5,12 +5,13 @@ import { impactInsights } from '@/data/impactInsights.js'
 import heroImage from '@/assets/lakeside_cohort_graduation.png'
 import villageSavingsImage from '@/assets/village_savings_saccos.png'
 import { CalendarDays, Tag } from 'lucide-react'
+import { AccentPill } from '@/components/AccentPill.jsx'
 
 const categories = ['All', 'Impact', 'Tech', 'Press']
 
 const categoryPalette = {
   Impact: 'bg-[color-mix(in_srgb,var(--brand-emerald)_12%,#ffffff_88%)] text-[var(--brand-emerald)] border-[var(--brand-emerald)]/20',
-  Tech: 'bg-[color-mix(in_srgb,var(--brand-gold)_15%,#ffffff_85%)] text-[color-mix(in_srgb,var(--brand-emerald)_70%,#4c3410_30%)] border-[var(--brand-gold)]/30',
+  Tech: 'bg-[color-mix(in_srgb,var(--brand-emerald)_12%,#ffffff_88%)] text-[color-mix(in_srgb,var(--brand-emerald)_75%,#1d4232_25%)] border-[var(--brand-emerald)]/25',
   Press: 'bg-[color-mix(in_srgb,var(--brand-emerald)_8%,#fdf4d5_92%)] text-[color-mix(in_srgb,var(--brand-emerald)_65%,#6d4b12_35%)] border-[var(--brand-emerald)]/10',
 }
 
@@ -27,7 +28,9 @@ export default function NewsUpdates() {
         <div className="mx-auto max-w-6xl px-4">
           <div className="grid gap-10 lg:grid-cols-[1.2fr_1fr] lg:items-center">
             <div>
-              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">News & updates</p>
+              <AccentPill size="sm" className="tracking-[0.25em]">
+                News & updates
+              </AccentPill>
               <h1 className="mt-4 text-4xl font-bold text-[var(--brand-emerald)]">Stories from the field and product desk</h1>
               <p className="mt-4 max-w-3xl text-base text-slate-600">
                 We publish quarterly impact notes, technology deep dives, and press announcements from Skooli’s mission across Uganda.
@@ -79,7 +82,7 @@ export default function NewsUpdates() {
                       </div>
                     ) : null}
                     <div className="space-y-4 p-6">
-                      <div className="flex items-center gap-3 text-xs uppercase tracking-[0.3em] text-[var(--brand-gold)]">
+                      <div className="flex items-center gap-3 text-xs uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_75%,#032823_25%)]">
                         <CalendarDays className="size-4" /> {entry.date}
                       </div>
                       <h2 className="text-2xl font-semibold text-[var(--brand-emerald)]">{entry.title}</h2>
@@ -99,12 +102,16 @@ export default function NewsUpdates() {
 
             <aside className="space-y-6">
               <div className="rounded-3xl bg-white p-6 shadow-lg shadow-black/5">
-                <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Join our newsletter</p>
+                <AccentPill size="sm" className="tracking-[0.25em]">
+                  Join our newsletter
+                </AccentPill>
                 <p className="mt-3 text-sm text-slate-600">Receive monthly insights on logistics, impact, and technology.</p>
                 <NewsletterSignupModule layout="vertical" includeDownloadLink={false} className="mt-4" />
               </div>
               <div className="rounded-3xl bg-white p-6 shadow-lg shadow-black/5">
-                <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Impact insights</p>
+                <AccentPill size="sm" className="tracking-[0.25em]">
+                  Impact insights
+                </AccentPill>
                 <p className="mt-3 text-sm text-slate-600">Quick metrics from our investor dashboard.</p>
                 <figure className="mt-4 overflow-hidden rounded-2xl border border-[var(--brand-emerald)]/15 bg-[var(--brand-cream)]/60">
                   <img
@@ -119,15 +126,19 @@ export default function NewsUpdates() {
                 <div className="mt-6 grid gap-4">
                   {impactInsights.map((item) => (
                     <div key={item.label} className="rounded-2xl border border-[var(--brand-emerald)]/15 bg-[var(--brand-cream)]/70 p-4">
-                      <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">{item.label}</p>
+                      <AccentPill size="xs" className="tracking-[0.25em]">
+                        {item.label}
+                      </AccentPill>
                       <p className="mt-2 text-xl font-bold text-[var(--brand-emerald)]">{item.metric}</p>
                       <p className="mt-1 text-xs text-slate-600">{item.detail}</p>
                     </div>
                   ))}
-                </div>
+              </div>
               </div>
               <div className="rounded-3xl bg-white p-6 shadow-lg shadow-black/5">
-                <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Twitter</p>
+                <AccentPill size="sm" className="tracking-[0.25em]">
+                  Twitter
+                </AccentPill>
                 <p className="mt-3 text-sm text-slate-600">Latest threads from @skooli_africa.</p>
                 <div className="mt-4 overflow-hidden rounded-2xl border border-slate-200">
                   <iframe

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -8,7 +8,7 @@ export default function NotFound() {
       <p className="mt-4 max-w-lg text-base text-slate-600">
         We couldn’t find that page. Explore Skooli’s executive site from the home page instead.
       </p>
-      <Button className="mt-6 rounded-md bg-[var(--brand-gold)] px-6 py-3 text-white hover:bg-[color-mix(in_srgb,var(--brand-gold)_80%,#000_20%)]" asChild>
+      <Button className="mt-6 rounded-md bg-[var(--brand-emerald)] px-6 py-3 text-white shadow-lg shadow-[var(--brand-emerald)]/20 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]" asChild>
         <Link to="/">Return home</Link>
       </Button>
     </div>

--- a/src/pages/PartnerWithUs.jsx
+++ b/src/pages/PartnerWithUs.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Building, Landmark, Handshake, Church, BarChart3, PieChart, LineChart, ClipboardCheck, ExternalLink } from 'lucide-react'
 import { Button } from '@/components/ui/button.jsx'
 import ComplianceKit from '@/components/ComplianceKit.jsx'
+import { AccentPill } from '@/components/AccentPill.jsx'
 
 const segments = {
   ngos: {
@@ -112,7 +113,9 @@ export default function PartnerWithUs() {
     <div className="bg-[var(--brand-cream)]">
       <section className="bg-white py-16">
         <div className="mx-auto max-w-6xl px-4">
-          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Partnerships</p>
+          <AccentPill size="sm" className="tracking-[0.25em]">
+            Partnerships
+          </AccentPill>
           <div className="mt-6 grid gap-8 lg:grid-cols-[1.5fr_1fr] lg:items-center">
             <div>
               <h1 className="text-4xl font-bold text-[var(--brand-emerald)]">Partner with Skooli to scale dignified access</h1>
@@ -124,7 +127,7 @@ export default function PartnerWithUs() {
               <p className="text-sm font-semibold uppercase tracking-[0.3em] text-white/70">Dynamic Typeform</p>
               <p className="mt-2 text-lg">Tell us how you’d like to collaborate and a partnership lead will respond within 48 hours.</p>
               <Button
-                className="mt-6 rounded-md bg-[var(--brand-gold)] px-6 py-3 text-white shadow hover:bg-[color-mix(in_srgb,var(--brand-gold)_80%,#000_20%)]"
+                className="mt-6 rounded-md bg-[var(--brand-emerald)] px-6 py-3 text-white shadow-lg shadow-[var(--brand-emerald)]/20 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]"
                 asChild
               >
                 <a href="https://form.typeform.com/to/skooli-partner" target="_blank" rel="noreferrer">
@@ -144,8 +147,8 @@ export default function PartnerWithUs() {
                 type="button"
                 className={`flex flex-col items-start gap-2 rounded-2xl border px-4 py-4 text-left text-sm font-semibold transition ${
                   activeSegment === 'ngos'
-                    ? 'border-[var(--brand-gold)] bg-[var(--brand-cream)] text-[var(--brand-emerald)]'
-                    : 'border-transparent bg-white hover:border-[var(--brand-gold)]/40 hover:bg-[var(--brand-cream)]'
+                    ? 'border-[var(--brand-emerald)] bg-[color-mix(in_srgb,var(--brand-cream)_82%,#ffffff_18%)] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] shadow-inner shadow-white/60'
+                    : 'border-transparent bg-white hover:border-[var(--brand-emerald)]/40 hover:bg-[color-mix(in_srgb,var(--brand-cream)_82%,#ffffff_18%)]'
                 }`}
                 onClick={() => setActiveSegment('ngos')}
               >
@@ -156,8 +159,8 @@ export default function PartnerWithUs() {
                 type="button"
                 className={`flex flex-col items-start gap-2 rounded-2xl border px-4 py-4 text-left text-sm font-semibold transition ${
                   activeSegment === 'governments'
-                    ? 'border-[var(--brand-gold)] bg-[var(--brand-cream)] text-[var(--brand-emerald)]'
-                    : 'border-transparent bg-white hover:border-[var(--brand-gold)]/40 hover:bg-[var(--brand-cream)]'
+                    ? 'border-[var(--brand-emerald)] bg-[color-mix(in_srgb,var(--brand-cream)_82%,#ffffff_18%)] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] shadow-inner shadow-white/60'
+                    : 'border-transparent bg-white hover:border-[var(--brand-emerald)]/40 hover:bg-[color-mix(in_srgb,var(--brand-cream)_82%,#ffffff_18%)]'
                 }`}
                 onClick={() => setActiveSegment('governments')}
               >
@@ -168,8 +171,8 @@ export default function PartnerWithUs() {
                 type="button"
                 className={`flex flex-col items-start gap-2 rounded-2xl border px-4 py-4 text-left text-sm font-semibold transition ${
                   activeSegment === 'suppliers'
-                    ? 'border-[var(--brand-gold)] bg-[var(--brand-cream)] text-[var(--brand-emerald)]'
-                    : 'border-transparent bg-white hover:border-[var(--brand-gold)]/40 hover:bg-[var(--brand-cream)]'
+                    ? 'border-[var(--brand-emerald)] bg-[color-mix(in_srgb,var(--brand-cream)_82%,#ffffff_18%)] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] shadow-inner shadow-white/60'
+                    : 'border-transparent bg-white hover:border-[var(--brand-emerald)]/40 hover:bg-[color-mix(in_srgb,var(--brand-cream)_82%,#ffffff_18%)]'
                 }`}
                 onClick={() => setActiveSegment('suppliers')}
               >
@@ -180,8 +183,8 @@ export default function PartnerWithUs() {
                 type="button"
                 className={`flex flex-col items-start gap-2 rounded-2xl border px-4 py-4 text-left text-sm font-semibold transition ${
                   activeSegment === 'churches'
-                    ? 'border-[var(--brand-gold)] bg-[var(--brand-cream)] text-[var(--brand-emerald)]'
-                    : 'border-transparent bg-white hover:border-[var(--brand-gold)]/40 hover:bg-[var(--brand-cream)]'
+                    ? 'border-[var(--brand-emerald)] bg-[color-mix(in_srgb,var(--brand-cream)_82%,#ffffff_18%)] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] shadow-inner shadow-white/60'
+                    : 'border-transparent bg-white hover:border-[var(--brand-emerald)]/40 hover:bg-[color-mix(in_srgb,var(--brand-cream)_82%,#ffffff_18%)]'
                 }`}
                 onClick={() => setActiveSegment('churches')}
               >
@@ -230,7 +233,9 @@ export default function PartnerWithUs() {
         <div className="mx-auto max-w-6xl px-4">
           <div className="grid gap-10 lg:grid-cols-[1.3fr_0.7fr] lg:items-start">
             <div>
-              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Stakeholder alignment</p>
+              <AccentPill size="sm" className="tracking-[0.25em]">
+                Stakeholder alignment
+              </AccentPill>
               <h2 className="mt-4 text-3xl font-semibold text-[var(--brand-emerald)]">Value narratives tailored to every decision maker</h2>
               <p className="mt-3 text-sm text-slate-600">
                 Ensure every stakeholder group understands the programme promise and has ready-to-share collateral for swift
@@ -245,7 +250,7 @@ export default function PartnerWithUs() {
                     </div>
                     <a
                       href={stakeholder.collateral.href}
-                      className="mt-4 inline-flex items-center gap-2 text-xs font-semibold text-[var(--brand-gold)] hover:text-[color-mix(in_srgb,var(--brand-gold)_80%,#000_20%)]"
+                      className="mt-4 inline-flex items-center gap-2 text-xs font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] underline decoration-[color-mix(in_srgb,var(--brand-emerald)_40%,#032823_60%)] decoration-2 underline-offset-4 hover:text-[var(--brand-emerald)]"
                       download={stakeholder.collateral.download}
                     >
                       {stakeholder.collateral.label}

--- a/src/pages/ShopNow.jsx
+++ b/src/pages/ShopNow.jsx
@@ -1,5 +1,6 @@
 import { ShoppingBag, ShieldCheck, Smartphone, Clock, Sparkles, PackageSearch } from 'lucide-react'
 import { Button } from '@/components/ui/button.jsx'
+import { AccentPill } from '@/components/AccentPill.jsx'
 
 const benefits = [
   {
@@ -47,13 +48,15 @@ export default function ShopNow() {
     <div className="bg-[var(--brand-cream)]">
       <section className="bg-white py-16">
         <div className="mx-auto max-w-5xl px-4 text-center">
-          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Parents & guardians</p>
+          <AccentPill size="sm" className="tracking-[0.25em]">
+            Parents & guardians
+          </AccentPill>
           <h1 className="mt-4 text-4xl font-bold text-[var(--brand-emerald)]">Shop, schedule, and track every supply with confidence</h1>
           <p className="mt-6 text-base text-slate-600">
             The Skooli Parent Portal puts everything in one place: curated bundles, secure payments, and live delivery alerts so your child never misses a school day.
           </p>
           <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
-            <Button className="rounded-md bg-[var(--brand-gold)] px-8 py-3 text-white shadow hover:bg-[color-mix(in_srgb,var(--brand-gold)_80%,#000_20%)]">
+            <Button className="rounded-md bg-[var(--brand-emerald)] px-8 py-3 text-white shadow-lg shadow-[var(--brand-emerald)]/20 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]">
               Launch Parent Portal
             </Button>
             <Button
@@ -90,10 +93,9 @@ export default function ShopNow() {
               </div>
             </div>
             <div className="rounded-3xl bg-white p-8 shadow-xl shadow-black/10">
-              <div className="flex items-center gap-3 text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">
-                <Sparkles className="size-5" />
+              <AccentPill size="sm" icon={Sparkles} className="tracking-[0.25em]">
                 Demo view
-              </div>
+              </AccentPill>
               <div className="mt-6 space-y-4 text-left">
                 <div className="rounded-2xl border border-slate-200 p-4">
                   <p className="text-xs uppercase tracking-wide text-slate-500">Child accounts</p>
@@ -146,7 +148,9 @@ export default function ShopNow() {
       <section className="py-16">
         <div className="mx-auto max-w-6xl px-4">
           <div className="flex flex-col gap-6 text-center">
-            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Featured bundles</p>
+            <AccentPill size="sm" className="mx-auto tracking-[0.25em]">
+              Featured bundles
+            </AccentPill>
             <h2 className="text-3xl font-semibold text-[var(--brand-emerald)]">Term-perfect packs families rely on</h2>
             <p className="mx-auto max-w-2xl text-sm text-slate-600">
               Every bundle is co-designed with partner schools and refreshed each term based on curriculum updates and pastoral needs.
@@ -166,7 +170,7 @@ export default function ShopNow() {
                   ))}
                 </ul>
                 <p className="mt-4 text-lg font-semibold text-[var(--brand-emerald)]">{bundle.price}</p>
-                <Button className="mt-4 rounded-md bg-[var(--brand-gold)] text-white hover:bg-[color-mix(in_srgb,var(--brand-gold)_80%,#000_20%)]">
+                <Button className="mt-4 rounded-md bg-[var(--brand-emerald)] text-white shadow-lg shadow-[var(--brand-emerald)]/20 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]">
                   Pre-order
                 </Button>
               </div>

--- a/src/pages/TechnologyAI.jsx
+++ b/src/pages/TechnologyAI.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Bot, Map, Shield, Lock, Briefcase } from 'lucide-react'
+import { AccentPill } from '@/components/AccentPill.jsx'
 
 const agents = [
   {
@@ -50,7 +51,9 @@ export default function TechnologyAI() {
     <div className="bg-[var(--brand-cream)]">
       <section className="bg-white py-16">
         <div className="mx-auto max-w-6xl px-4">
-          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Technology & AI</p>
+          <AccentPill size="sm" className="tracking-[0.25em]">
+            Technology & AI
+          </AccentPill>
           <h1 className="mt-4 text-4xl font-bold text-[var(--brand-emerald)]">Infrastructure that keeps mission promises</h1>
           <p className="mt-4 max-w-3xl text-base text-slate-600">
             Skooli’s stack blends modern web technology, AI copilots, and secure integrations with mobile money and warehousing partners.
@@ -83,7 +86,9 @@ export default function TechnologyAI() {
                   type="button"
                   onClick={() => setOpenCard((prev) => (prev === agent.id ? '' : agent.id))}
                   className={`flex h-full flex-col rounded-3xl border p-6 text-left shadow-lg shadow-black/5 transition ${
-                    isOpen ? 'border-[var(--brand-gold)] bg-[var(--brand-cream)]' : 'border-transparent bg-white hover:border-[var(--brand-gold)]/40 hover:bg-[var(--brand-cream)]'
+                    isOpen
+                      ? 'border-[var(--brand-emerald)] bg-[color-mix(in_srgb,var(--brand-cream)_80%,#ffffff_20%)]'
+                      : 'border-transparent bg-white hover:border-[var(--brand-emerald)]/40 hover:bg-[color-mix(in_srgb,var(--brand-cream)_80%,#ffffff_20%)]'
                   }`}
                 >
                   <div className="flex items-center gap-3 text-[var(--brand-emerald)]">
@@ -91,7 +96,11 @@ export default function TechnologyAI() {
                     <h3 className="text-lg font-semibold">{agent.name}</h3>
                   </div>
                   <p className="mt-3 text-sm text-slate-600">{agent.summary}</p>
-                  {isOpen && <p className="mt-4 text-xs uppercase tracking-[0.3em] text-[var(--brand-gold)]">{agent.tech}</p>}
+                  {isOpen && (
+                    <AccentPill size="xs" className="mt-4 tracking-[0.25em]">
+                      {agent.tech}
+                    </AccentPill>
+                  )}
                 </button>
               )
             })}
@@ -133,7 +142,9 @@ export default function TechnologyAI() {
             ))}
           </div>
           <div className="mt-10 rounded-3xl bg-[var(--brand-cream)] p-6 shadow-lg shadow-black/5">
-            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Open roles</p>
+            <AccentPill size="sm" className="tracking-[0.25em]">
+              Open roles
+            </AccentPill>
             <p className="mt-3 text-sm text-slate-600">We’re expanding our engineering and AI teams. Join the waitlist for future roles.</p>
             <a
               className="mt-4 inline-flex items-center gap-2 rounded-md border border-[var(--brand-emerald)] px-4 py-2 text-sm font-semibold text-[var(--brand-emerald)] shadow hover:bg-[var(--brand-emerald)] hover:text-white"
@@ -158,7 +169,15 @@ function ArchitectureDiagram() {
       <rect x="20" y="30" width="160" height="80" rx="20" fill="var(--brand-emerald)" opacity="0.9" />
       <text x="100" y="75" textAnchor="middle" fontSize="14" fill="white">Web App</text>
 
-      <rect x="220" y="30" width="160" height="80" rx="20" fill="var(--brand-gold)" opacity="0.9" />
+      <rect
+        x="220"
+        y="30"
+        width="160"
+        height="80"
+        rx="20"
+        fill="color-mix(in srgb, var(--brand-emerald) 72%, var(--brand-emerald-light) 28%)"
+        opacity="0.9"
+      />
       <text x="300" y="75" textAnchor="middle" fontSize="14" fill="white">AI Layer</text>
 
       <rect x="420" y="30" width="160" height="80" rx="20" fill="var(--brand-emerald)" opacity="0.9" />
@@ -172,12 +191,28 @@ function ArchitectureDiagram() {
 
       <line x1="180" y1="70" x2="220" y2="70" stroke="var(--brand-emerald)" strokeWidth="4" markerEnd="url(#arrow)" />
       <line x1="380" y1="70" x2="420" y2="70" stroke="var(--brand-emerald)" strokeWidth="4" markerEnd="url(#arrow)" />
-      <line x1="300" y1="110" x2="200" y2="160" stroke="var(--brand-gold)" strokeWidth="4" markerEnd="url(#arrow)" />
-      <line x1="300" y1="110" x2="400" y2="160" stroke="var(--brand-gold)" strokeWidth="4" markerEnd="url(#arrow)" />
+      <line
+        x1="300"
+        y1="110"
+        x2="200"
+        y2="160"
+        stroke="color-mix(in srgb, var(--brand-emerald) 76%, var(--brand-emerald-light) 24%)"
+        strokeWidth="4"
+        markerEnd="url(#arrow)"
+      />
+      <line
+        x1="300"
+        y1="110"
+        x2="400"
+        y2="160"
+        stroke="color-mix(in srgb, var(--brand-emerald) 76%, var(--brand-emerald-light) 24%)"
+        strokeWidth="4"
+        markerEnd="url(#arrow)"
+      />
 
       <defs>
         <marker id="arrow" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
-          <path d="M0,0 L6,3 L0,6" fill="var(--brand-gold)" />
+          <path d="M0,0 L6,3 L0,6" fill="color-mix(in srgb, var(--brand-emerald) 76%, var(--brand-emerald-light) 24%)" />
         </marker>
       </defs>
     </svg>

--- a/src/pages/VisionImpact.jsx
+++ b/src/pages/VisionImpact.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Compass, Globe2, Users2, HeartHandshake, Quote, ArrowLeft, ArrowRight } from 'lucide-react'
+import { AccentPill } from '@/components/AccentPill.jsx'
 
 const pillars = [
   {
@@ -117,9 +118,9 @@ export default function VisionImpact() {
               </div>
             </div>
             <div className="rounded-3xl bg-[var(--brand-cream)] p-10 shadow-lg shadow-black/5">
-              <div className="flex items-center gap-3 text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">
-                <Compass className="size-5" /> Vision 2030
-              </div>
+              <AccentPill size="sm" icon={Compass} className="tracking-[0.25em]">
+                Vision 2030
+              </AccentPill>
               <p className="mt-5 text-lg text-[var(--brand-emerald)]">
                 Skooli envisions an Africa where access to education supplies is never a barrier to learning or dignity.
               </p>
@@ -151,9 +152,13 @@ export default function VisionImpact() {
                       cx={district.cx}
                       cy={district.cy}
                       r={district.radius}
-                      fill={district.id === activeDistrict.id ? 'var(--brand-gold)' : 'var(--brand-emerald)'}
-                      fillOpacity={district.id === activeDistrict.id ? 0.9 : 0.6}
-                      className="cursor-pointer transition hover:fill-[var(--brand-gold)]"
+                      fill={
+                        district.id === activeDistrict.id
+                          ? 'color-mix(in srgb, var(--brand-emerald) 76%, var(--brand-emerald-light) 24%)'
+                          : 'var(--brand-emerald)'
+                      }
+                      fillOpacity={district.id === activeDistrict.id ? 0.9 : 0.65}
+                      className="cursor-pointer transition hover:fill-[color-mix(in_srgb,var(--brand-emerald)_76%,var(--brand-emerald-light)_24%)]"
                       onMouseEnter={() => setActiveDistrict(district)}
                       onFocus={() => setActiveDistrict(district)}
                       tabIndex={0}
@@ -176,7 +181,7 @@ export default function VisionImpact() {
                       pointerEvents="none"
                     >
                       <div className="flex h-full flex-col justify-center rounded-2xl bg-[var(--brand-emerald)]/90 px-3 py-2 text-white shadow-lg ring-1 ring-white/30">
-                        <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">
+                        <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-white/80">
                           {district.name}
                         </p>
                         <p className="mt-1 text-xs font-semibold">
@@ -190,7 +195,9 @@ export default function VisionImpact() {
               </svg>
             </div>
             <div className="space-y-6">
-              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Impact map</p>
+              <AccentPill size="sm" className="tracking-[0.25em]">
+                Impact map
+              </AccentPill>
               <h2 className="text-3xl font-semibold text-[var(--brand-emerald)]">
                 District coverage grows every term
               </h2>
@@ -203,7 +210,9 @@ export default function VisionImpact() {
                   <strong>{activeDistrict.schools}</strong> partner schools •
                   <strong> {activeDistrict.studentLabel}</strong> students supported
                 </p>
-                <p className="mt-3 text-xs uppercase tracking-[0.3em] text-[var(--brand-gold)]">Data refreshed weekly</p>
+                <AccentPill size="xs" className="mt-3 tracking-[0.25em]">
+                  Data refreshed weekly
+                </AccentPill>
               </div>
             </div>
           </div>
@@ -212,7 +221,9 @@ export default function VisionImpact() {
 
       <section className="bg-white py-16">
         <div className="mx-auto max-w-6xl px-4">
-          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">SDG alignment</p>
+          <AccentPill size="sm" className="tracking-[0.25em]">
+            SDG alignment
+          </AccentPill>
           <h2 className="mt-4 text-3xl font-semibold text-[var(--brand-emerald)]">Anchored to global goals</h2>
           <p className="mt-3 text-sm text-slate-600">
             Every cohort of learners we serve is linked to a Sustainable Development Goal target and tracked through quarterly
@@ -231,7 +242,7 @@ export default function VisionImpact() {
                     <p className="text-sm font-semibold uppercase tracking-[0.3em]">{sdg}</p>
                   </div>
                   <p className="mt-4 text-base text-slate-600 group-hover:text-white/90">{metric}</p>
-                  <p className="mt-3 text-xs font-semibold uppercase tracking-[0.2em] text-[var(--brand-gold)] group-hover:text-[var(--brand-gold)]/90">
+                  <p className="mt-3 text-xs font-semibold uppercase tracking-[0.2em] text-[color-mix(in_srgb,var(--brand-emerald)_76%,var(--brand-emerald-light)_24%)] group-hover:text-white/80">
                     Independently verified twice yearly
                   </p>
                 </div>
@@ -243,9 +254,11 @@ export default function VisionImpact() {
 
       <section className="py-16">
         <div className="mx-auto max-w-4xl px-4 text-center">
-          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-gold)]">Story carousel</p>
+          <AccentPill size="sm" className="mx-auto tracking-[0.25em]">
+            Story carousel
+          </AccentPill>
           <div className="relative mt-8 overflow-hidden rounded-3xl bg-white p-10 shadow-lg shadow-black/10">
-            <Quote className="absolute left-6 top-6 size-8 text-[var(--brand-gold)]" />
+            <Quote className="absolute left-6 top-6 size-8 text-[color-mix(in_srgb,var(--brand-emerald)_76%,var(--brand-emerald-light)_24%)]" />
             <p className="text-lg text-[var(--brand-emerald)]">{stories[storyIndex].narrative}</p>
             <p className="mt-6 text-sm font-semibold text-slate-600">{stories[storyIndex].name}</p>
             <div className="mt-8 flex items-center justify-center gap-3">
@@ -260,7 +273,11 @@ export default function VisionImpact() {
                 {stories.map((_, index) => (
                   <span
                     key={index}
-                    className={`h-2 w-8 rounded-full ${index === storyIndex ? 'bg-[var(--brand-gold)]' : 'bg-slate-200'}`}
+                    className={`h-2 w-8 rounded-full ${
+                      index === storyIndex
+                        ? 'bg-[color-mix(in_srgb,var(--brand-emerald)_76%,var(--brand-emerald-light)_24%)]'
+                        : 'bg-slate-200'
+                    }`}
                   />
                 ))}
               </div>


### PR DESCRIPTION
## Summary
- add an AccentPill helper and swap gold-on-light labels across every page for high-contrast emerald treatments
- refresh buttons, hover/focus states, and call-to-action links to keep text within controls and improve readability sitewide
- tune maps, infographics, and social widgets so highlight colors align with the new accessible palette on each route

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_6901a37415d0832b983e1413330e1d11