### PR TITLE
Add typography tokens and standardize text styling

### DIFF
--- a/src/components/ComplianceKit.jsx
+++ b/src/components/ComplianceKit.jsx
@@ -34,7 +34,7 @@ export default function ComplianceKit({
       <AccentPill size="sm" className="tracking-[0.25em]">
         {title}
       </AccentPill>
-      <p className="mt-3 text-sm text-slate-600">{blurb}</p>
+      <p className="mt-3 typography-body-sm text-slate-600">{blurb}</p>
       <ul className="mt-6 space-y-4">
         {documents.map((document) => {
           const Icon = document.icon
@@ -45,15 +45,15 @@ export default function ComplianceKit({
                   <Icon className="size-4" aria-hidden="true" />
                 </span>
                 <div>
-                  <p className="text-sm font-semibold text-[var(--brand-emerald)]">{document.title}</p>
-                  <p className="text-xs text-slate-600">{document.description}</p>
+                  <p className="typography-body-sm font-semibold text-[var(--brand-emerald)]">{document.title}</p>
+                  <p className="typography-body-xs text-slate-600">{document.description}</p>
                 </div>
               </div>
               <div>
                 <a
                   href={document.href}
                   download
-                  className="inline-flex items-center gap-2 text-xs font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] underline decoration-[color-mix(in_srgb,var(--brand-emerald)_45%,#032823_55%)] decoration-2 underline-offset-4 hover:text-[var(--brand-emerald)]"
+                  className="inline-flex items-center gap-2 typography-body-xs font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] underline decoration-[color-mix(in_srgb,var(--brand-emerald)_45%,#032823_55%)] decoration-2 underline-offset-4 hover:text-[var(--brand-emerald)]"
                 >
                   Download template
                   <FileDown className="size-3" aria-hidden="true" />

--- a/src/components/ExpansionJourney.jsx
+++ b/src/components/ExpansionJourney.jsx
@@ -59,7 +59,7 @@ export default function ExpansionJourney() {
             <p className="inline-flex w-max items-center rounded-full border border-white/20 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white/90 shadow-lg shadow-black/10 backdrop-blur">
               Expansion journey
             </p>
-            <h2 className="mt-6 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+            <h2 className="mt-6 typography-heading-2 font-semibold tracking-tight text-white">
               From pilot validation to multi-country scale
             </h2>
             <ul className="mt-8 space-y-4">
@@ -69,7 +69,7 @@ export default function ExpansionJourney() {
                     className="mr-4 inline-block size-4 rounded-full border"
                     style={{ background: item.background, borderColor: item.border }}
                   />
-                  <span className="text-base font-medium text-white/85">{item.name}</span>
+                  <span className="typography-body-md font-medium text-white/85">{item.name}</span>
                 </li>
               ))}
             </ul>
@@ -90,8 +90,8 @@ export default function ExpansionJourney() {
                     <AccentPill tone="inverse" size="xs" className="tracking-[0.25em]">
                       {timeline}
                     </AccentPill>
-                    <p className="mt-1 text-lg font-semibold text-white">{title}</p>
-                    <p className="mt-2 text-sm text-white/85">{summary}</p>
+                    <p className="mt-1 typography-heading-4 font-semibold text-white">{title}</p>
+                    <p className="mt-2 typography-body-sm text-white/85">{summary}</p>
                   </div>
                 ))}
               </figcaption>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -49,17 +49,17 @@ export default function Footer() {
         <div className="grid grid-cols-1 gap-12 md:grid-cols-2 lg:grid-cols-4">
           <div className="space-y-6">
             <div>
-              <h2 className="text-2xl font-bold text-[var(--brand-emerald)]">Skooli</h2>
-              <p className="mt-4 max-w-xs text-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
+              <h2 className="typography-heading-3 font-bold text-[var(--brand-emerald)]">Skooli</h2>
+              <p className="mt-4 max-w-xs typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
                 Education logistics built for every Ugandan learner. Ethically sourced.
                 Efficiently delivered. Faithfully stewarded.
               </p>
             </div>
-            <div className="space-y-4 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
+            <div className="space-y-4 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
               <div className="flex items-start gap-3">
                 <MapPin className="mt-0.5 size-5 text-[var(--brand-emerald)]" />
                 <div>
-                  <p className="font-semibold text-[var(--brand-emerald)]">Uganda HQ</p>
+                  <p className="typography-body-sm font-semibold text-[var(--brand-emerald)]">Uganda HQ</p>
                   <p>Plot 12, Hassim Road, Buziga</p>
                   <p>Kampala, Uganda</p>
                 </div>
@@ -67,20 +67,20 @@ export default function Footer() {
               <div className="flex items-start gap-3">
                 <MapPin className="mt-0.5 size-5 text-[var(--brand-emerald)]" />
                 <div>
-                  <p className="font-semibold text-[var(--brand-emerald)]">UK Office</p>
+                  <p className="typography-body-sm font-semibold text-[var(--brand-emerald)]">UK Office</p>
                   <p>128 City Road</p>
                   <p>London, EC1V 2NX</p>
                 </div>
               </div>
               <div className="flex items-center gap-3">
                 <Mail className="size-5 text-[var(--brand-emerald)]" />
-                <a className="font-semibold text-[var(--brand-emerald)] transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]" href="mailto:hello@skooli.africa">
+                <a className="typography-body-sm font-semibold text-[var(--brand-emerald)] transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]" href="mailto:hello@skooli.africa">
                   hello@skooli.africa
                 </a>
               </div>
               <div className="flex items-center gap-3">
                 <Phone className="size-5 text-[var(--brand-emerald)]" />
-                <a className="font-semibold text-[var(--brand-emerald)] transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]" href="tel:+256414000000">
+                <a className="typography-body-sm font-semibold text-[var(--brand-emerald)] transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]" href="tel:+256414000000">
                   +256 414 000 000
                 </a>
               </div>
@@ -117,8 +117,8 @@ export default function Footer() {
           </div>
 
           <div>
-            <h3 className="text-lg font-semibold text-[var(--brand-emerald)]">Company</h3>
-            <ul className="mt-6 space-y-3 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
+            <h3 className="typography-heading-4 font-semibold text-[var(--brand-emerald)]">Company</h3>
+            <ul className="mt-6 space-y-3 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
               {footerSections.company.map((item) => (
                 <li key={item.label}>
                   <Link className="transition hover:text-[var(--brand-emerald)]" to={item.to}>
@@ -130,8 +130,8 @@ export default function Footer() {
           </div>
 
           <div>
-            <h3 className="text-lg font-semibold text-[var(--brand-emerald)]">Services</h3>
-            <ul className="mt-6 space-y-3 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
+            <h3 className="typography-heading-4 font-semibold text-[var(--brand-emerald)]">Services</h3>
+            <ul className="mt-6 space-y-3 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
               {footerSections.services.map((item) => (
                 <li key={item.label}>
                   <Link className="transition hover:text-[var(--brand-emerald)]" to={item.to}>
@@ -143,8 +143,8 @@ export default function Footer() {
           </div>
 
           <div>
-            <h3 className="text-lg font-semibold text-[var(--brand-emerald)]">Resources & Legal</h3>
-            <ul className="mt-6 space-y-3 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
+            <h3 className="typography-heading-4 font-semibold text-[var(--brand-emerald)]">Resources & Legal</h3>
+            <ul className="mt-6 space-y-3 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
               {[...footerSections.resources, ...footerSections.legal].map((item) => (
                 <li key={item.label}>
                   <Link className="transition hover:text-[var(--brand-emerald)]" to={item.to}>
@@ -154,8 +154,8 @@ export default function Footer() {
               ))}
             </ul>
             <div className="mt-8 space-y-3 rounded-2xl border border-[var(--brand-emerald)]/15 bg-[color-mix(in_srgb,var(--brand-cream)_75%,#ffffff_25%)] p-4 shadow-sm">
-              <p className="text-sm font-semibold text-[var(--brand-emerald)]">Stay in the loop</p>
-              <p className="text-xs text-[color-mix(in_srgb,var(--brand-emerald)_70%,#4c625b_30%)]">Monthly executive briefings on logistics, impact and technology.</p>
+              <p className="typography-body-sm font-semibold text-[var(--brand-emerald)]">Stay in the loop</p>
+              <p className="typography-body-xs text-[color-mix(in_srgb,var(--brand-emerald)_70%,#4c625b_30%)]">Monthly executive briefings on logistics, impact and technology.</p>
               <form
                 className="flex items-center gap-2"
                 onSubmit={(event) => {
@@ -169,7 +169,7 @@ export default function Footer() {
                 }}
               >
                 <input
-                  className="h-10 flex-1 rounded-full border border-[var(--brand-emerald)]/25 bg-white px-3 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)] placeholder:text-[color-mix(in_srgb,var(--brand-emerald)_45%,#8da49a_55%)] focus:border-[var(--brand-emerald)] focus:outline-none"
+                  className="h-10 flex-1 rounded-full border border-[var(--brand-emerald)]/25 bg-white px-3 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)] placeholder:text-[color-mix(in_srgb,var(--brand-emerald)_45%,#8da49a_55%)] focus:border-[var(--brand-emerald)] focus:outline-none"
                   type="email"
                   name="email"
                   aria-label="Email for newsletter"
@@ -178,7 +178,7 @@ export default function Footer() {
                 />
                 <button
                   type="submit"
-                  className="flex h-10 items-center justify-center rounded-full bg-[var(--brand-emerald)] px-4 text-sm font-semibold text-white shadow-sm shadow-black/10 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]"
+                  className="flex h-10 items-center justify-center rounded-full bg-[var(--brand-emerald)] px-4 typography-body-sm font-semibold text-white shadow-sm shadow-black/10 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]"
                 >
                   <Send className="size-4" />
                 </button>
@@ -187,7 +187,7 @@ export default function Footer() {
           </div>
         </div>
         <div className="mt-12 border-t border-[var(--brand-emerald)]/20 pt-6">
-          <div className="flex flex-col gap-4 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_72%,#032823_28%)] md:flex-row md:items-center md:justify-between">
+          <div className="flex flex-col gap-4 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_72%,#032823_28%)] md:flex-row md:items-center md:justify-between">
             <p>© {new Date().getFullYear()} Skooli Technologies Group Ltd. All rights reserved.</p>
             <div className="flex items-center gap-2">
               <span>Made with</span>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -54,10 +54,10 @@ export default function Hero() {
           <AccentPill tone="inverse" size="sm" className="bg-white/20">
             Executive briefing
           </AccentPill>
-          <h1 className="mt-6 text-4xl font-semibold leading-tight text-white sm:text-5xl lg:text-6xl">
+          <h1 className="mt-6 typography-display font-semibold text-white">
             Operational assurance for national education pilots
           </h1>
-          <p className="mt-6 text-xl font-medium text-white/90">
+          <p className="mt-6 typography-body-lg font-medium text-white/90">
             Skooli deploys accountable facilitators, verified suppliers, and transparent financial rails so ministries see auditable results from the first cohort through national scale.
           </p>
           <div className="mt-10">

--- a/src/components/HeroStats.jsx
+++ b/src/components/HeroStats.jsx
@@ -11,8 +11,8 @@ export default function HeroStats() {
           {items.map((item) => (
             <div key={item.label} className="flex items-center justify-center rounded-xl p-4 text-center">
               <div>
-                <p className="text-2xl font-bold text-[var(--brand-emerald)] sm:text-3xl">{item.value}</p>
-                <p className="mt-1 text-sm font-medium text-[color-mix(in_srgb,var(--brand-emerald)_25%,#05382c_75%)]">
+                <p className="typography-heading-3 font-bold text-[var(--brand-emerald)]">{item.value}</p>
+                <p className="mt-1 typography-body-sm font-medium text-[color-mix(in_srgb,var(--brand-emerald)_25%,#05382c_75%)]">
                   {item.label}
                 </p>
               </div>

--- a/src/components/HowItWorksPreview.jsx
+++ b/src/components/HowItWorksPreview.jsx
@@ -29,11 +29,11 @@ export default function HowItWorksPreview() {
             <AccentPill size="sm" className="tracking-[0.25em]">
               How it works
             </AccentPill>
-            <h2 className="mt-4 text-3xl font-semibold text-[var(--brand-emerald)] sm:text-4xl">A frictionless supply chain from cart to classroom</h2>
+            <h2 className="mt-4 typography-heading-2 font-semibold text-[var(--brand-emerald)]">A frictionless supply chain from cart to classroom</h2>
           </div>
           <Link
             to="/how-it-works"
-            className="text-sm font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] transition hover:text-[var(--brand-emerald)]"
+            className="typography-body-sm font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] transition hover:text-[var(--brand-emerald)]"
           >
             Explore the full playbook →
           </Link>
@@ -50,8 +50,8 @@ export default function HowItWorksPreview() {
                   <StepIcon className="size-6" aria-hidden="true" />
                 </div>
                 <p className="mt-4 text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Step {index + 1}</p>
-                <h3 className="mt-2 text-xl font-semibold text-[var(--brand-emerald)]">{title}</h3>
-                <p className="mt-2 text-sm text-slate-600">{description}</p>
+                <h3 className="mt-2 typography-heading-4 font-semibold text-[var(--brand-emerald)]">{title}</h3>
+                <p className="mt-2 typography-body-sm text-slate-600">{description}</p>
               </div>
             )
           })}

--- a/src/components/ImpactSnapshot.jsx
+++ b/src/components/ImpactSnapshot.jsx
@@ -39,11 +39,11 @@ export default function ImpactSnapshot() {
             <AccentPill tone="inverse" size="sm" className="bg-white/25">
               Executive Dashboard Sync
             </AccentPill>
-            <p className="mt-6 text-sm font-semibold uppercase tracking-[0.3em] text-white/70">Impact snapshot</p>
-            <h2 className="mt-4 text-3xl font-semibold leading-tight sm:text-4xl">
+            <p className="mt-6 typography-body-sm font-semibold uppercase tracking-[0.3em] text-white/70">Impact snapshot</p>
+            <h2 className="mt-4 typography-heading-2 font-semibold">
               Real-time mission metrics from our executive dashboard
             </h2>
-            <p className="mt-4 max-w-xl text-sm text-white/80">
+            <p className="mt-4 max-w-xl typography-body-sm text-white/80">
               Figures sync hourly from our internal CMS—giving partners and investors visibility into performance and promises delivered.
             </p>
             <div className="mt-6 flex flex-wrap items-center gap-4">
@@ -51,7 +51,7 @@ export default function ImpactSnapshot() {
                 href="/downloads/skooli-impact-report-2025.pdf"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center rounded-full bg-white px-5 py-3 text-sm font-semibold text-[var(--brand-emerald)] shadow-lg shadow-black/20 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_12%,#ffffff_88%)] hover:text-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]"
+                className="inline-flex items-center rounded-full bg-white px-5 py-3 typography-body-sm font-semibold text-[var(--brand-emerald)] shadow-lg shadow-black/20 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_12%,#ffffff_88%)] hover:text-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]"
               >
                 Download the executive impact briefing (PDF)
               </a>
@@ -59,15 +59,15 @@ export default function ImpactSnapshot() {
                 href="/downloads/skooli-unit-economics-2025.pdf"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center rounded-full border border-white/30 px-5 py-3 text-sm font-semibold text-white transition hover:-translate-y-0.5 hover:border-white hover:bg-white/10"
+                className="inline-flex items-center rounded-full border border-white/30 px-5 py-3 typography-body-sm font-semibold text-white transition hover:-translate-y-0.5 hover:border-white hover:bg-white/10"
               >
                 View unit economics supplement (PDF)
               </a>
             </div>
           </div>
           <div className="rounded-2xl border border-white/20 bg-white/10 p-6 shadow-lg shadow-black/10 backdrop-blur">
-            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-white/70">Updated</p>
-            <p className="text-2xl font-semibold">29 Jan 2025 • 14:00 EAT</p>
+            <p className="typography-body-sm font-semibold uppercase tracking-[0.3em] text-white/70">Updated</p>
+            <p className="typography-heading-3 font-semibold">29 Jan 2025 • 14:00 EAT</p>
           </div>
         </div>
         <div className="mt-12 grid gap-6 sm:grid-cols-3" ref={ref}>
@@ -82,12 +82,12 @@ export default function ImpactSnapshot() {
                 key={label}
                 className="rounded-2xl border border-white/15 bg-white/10 p-8 text-center shadow-lg shadow-black/15 backdrop-blur transition hover:bg-white/15"
               >
-                <p className="text-sm font-semibold uppercase tracking-[0.3em] text-white/70">{label}</p>
-                <p className="mt-4 text-4xl font-bold">
+                <p className="typography-body-sm font-semibold uppercase tracking-[0.3em] text-white/70">{label}</p>
+                <p className="mt-4 typography-heading-1 font-bold">
                   {displayValue.toLocaleString()}
                   {suffix || ''}
                 </p>
-                <p className="mt-2 text-sm text-white/80">Live counter powered by Sanity CMS</p>
+                <p className="mt-2 typography-body-sm text-white/80">Live counter powered by Sanity CMS</p>
               </div>
             )
           })}

--- a/src/components/NewsletterCTA.jsx
+++ b/src/components/NewsletterCTA.jsx
@@ -9,16 +9,16 @@ export default function NewsletterCTA() {
           <div className="flex flex-col gap-8">
             <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
               <div className="max-w-2xl">
-                <span className="inline-flex items-center rounded-full bg-[color-mix(in_srgb,var(--brand-emerald)_10%,#ffffff_90%)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-[var(--brand-emerald)] shadow-inner shadow-white">
+                <span className="inline-flex items-center rounded-full bg-[color-mix(in_srgb,var(--brand-emerald)_10%,#ffffff_90%)] px-4 py-2 typography-body-xs font-semibold uppercase tracking-[0.3em] text-[var(--brand-emerald)] shadow-inner shadow-white">
                   Executive Dashboard Sync
                 </span>
-                <p className="mt-4 inline-flex items-center gap-2 rounded-full border border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_75%,#ffffff_25%)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
+                <p className="mt-4 inline-flex items-center gap-2 rounded-full border border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_75%,#ffffff_25%)] px-3 py-1 typography-body-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
                   Newsletter
                 </p>
-                <h2 className="mt-4 text-3xl font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_88%,#032823_12%)]">
+                <h2 className="mt-4 typography-heading-2 font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_88%,#032823_12%)]">
                   Executive updates delivered monthly
                 </h2>
-                <p className="mt-3 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_35%,#05382c_65%)]">
+                <p className="mt-3 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_35%,#05382c_65%)]">
                   Subscribe for Mailchimp briefings on impact milestones, product launches, and treasury notes. Every confirmation email now includes the latest PDF dashboard sync for your leadership team.
                 </p>
               </div>
@@ -28,21 +28,21 @@ export default function NewsletterCTA() {
             <div className="rounded-3xl border border-[var(--brand-emerald)]/15 bg-white/70 p-6">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div>
-                  <p className="inline-flex items-center gap-2 rounded-full border border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_70%,#ffffff_30%)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
+                  <p className="inline-flex items-center gap-2 rounded-full border border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_70%,#ffffff_30%)] px-3 py-1 typography-body-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
                     Impact Insights
                   </p>
-                  <h3 className="mt-2 text-xl font-semibold text-[var(--brand-emerald)]">Operational highlights from the latest quarter</h3>
+                  <h3 className="mt-2 typography-heading-4 font-semibold text-[var(--brand-emerald)]">Operational highlights from the latest quarter</h3>
                 </div>
-                <span className="rounded-full border border-[var(--brand-emerald)]/15 bg-[color-mix(in_srgb,var(--brand-emerald)_8%,#ffffff_92%)] px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
+                <span className="rounded-full border border-[var(--brand-emerald)]/15 bg-[color-mix(in_srgb,var(--brand-emerald)_8%,#ffffff_92%)] px-4 py-1 typography-body-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
                   Q3 2025
                 </span>
               </div>
               <div className="mt-6 grid gap-4 sm:grid-cols-3">
                 {impactInsights.map((item) => (
                   <div key={item.label} className="rounded-2xl border border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_65%,#ffffff_35%)] p-4">
-                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">{item.label}</p>
-                    <p className="mt-3 text-2xl font-bold text-[var(--brand-emerald)]">{item.metric}</p>
-                    <p className="mt-2 text-xs text-slate-600">{item.detail}</p>
+                    <p className="typography-body-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">{item.label}</p>
+                    <p className="mt-3 typography-heading-3 font-bold text-[var(--brand-emerald)]">{item.metric}</p>
+                    <p className="mt-2 typography-body-xs text-slate-600">{item.detail}</p>
                   </div>
                 ))}
               </div>

--- a/src/components/NewsletterSignupModule.jsx
+++ b/src/components/NewsletterSignupModule.jsx
@@ -32,14 +32,14 @@ export function NewsletterSignupModule({ layout = 'horizontal', includeDownloadL
           value={email}
           onChange={(event) => setEmail(event.target.value)}
           placeholder="you@organisation.com"
-          className={`h-12 flex-1 rounded-full border border-[color-mix(in_srgb,var(--brand-emerald)_25%,#ffffff)] bg-white px-4 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_75%,#05382c_25%)] placeholder:text-[color-mix(in_srgb,var(--brand-emerald)_35%,#8b9f99_65%)] focus:border-[var(--brand-emerald)] focus:outline-none ${
+          className={`h-12 flex-1 rounded-full border border-[color-mix(in_srgb,var(--brand-emerald)_25%,#ffffff)] bg-white px-4 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_75%,#05382c_25%)] placeholder:text-[color-mix(in_srgb,var(--brand-emerald)_35%,#8b9f99_65%)] focus:border-[var(--brand-emerald)] focus:outline-none ${
             isHorizontal ? '' : 'w-full'
           }`}
           aria-label="Email address"
         />
         <button
           type="submit"
-          className="flex h-12 items-center justify-center rounded-full bg-[var(--brand-emerald)] px-6 text-sm font-semibold text-white shadow-lg shadow-black/15 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] whitespace-nowrap"
+          className="flex h-12 items-center justify-center rounded-full bg-[var(--brand-emerald)] px-6 typography-body-sm font-semibold text-white shadow-lg shadow-black/15 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] whitespace-nowrap"
           disabled={status === 'loading'}
         >
           {status === 'loading' ? 'Delivering…' : status === 'success' ? 'Briefing Sent!' : 'Send briefing PDF'}
@@ -51,7 +51,7 @@ export function NewsletterSignupModule({ layout = 'horizontal', includeDownloadL
           href="/downloads/skooli-pitch-deck-q3-2025.pdf"
           target="_blank"
           rel="noopener noreferrer"
-          className="mt-4 inline-flex items-center text-sm font-semibold text-[var(--brand-emerald)] underline decoration-[color-mix(in_srgb,var(--brand-emerald)_45%,#032823_55%)] decoration-2 underline-offset-4 transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]"
+          className="mt-4 inline-flex items-center typography-body-sm font-semibold text-[var(--brand-emerald)] underline decoration-[color-mix(in_srgb,var(--brand-emerald)_45%,#032823_55%)] decoration-2 underline-offset-4 transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]"
         >
           Download the board briefing packet (PDF)
         </a>

--- a/src/components/QuickGateways.jsx
+++ b/src/components/QuickGateways.jsx
@@ -32,11 +32,11 @@ export default function QuickGateways() {
             <AccentPill size="sm" className="tracking-[0.25em]">
               Our Services
             </AccentPill>
-            <h2 className="mt-4 text-3xl font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_88%,#032823_12%)] sm:text-4xl">
+            <h2 className="mt-4 typography-heading-2 font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_88%,#032823_12%)]">
               Enterprise-ready solutions for every stakeholder
             </h2>
           </div>
-          <p className="max-w-xl text-base text-[color-mix(in_srgb,var(--brand-emerald)_35%,#05382c_65%)]">
+          <p className="max-w-xl typography-body-md text-[color-mix(in_srgb,var(--brand-emerald)_35%,#05382c_65%)]">
             Each of our services is designed with enterprise-grade security and reporting, ensuring that stakeholders at every level have the tools they need to succeed.
           </p>
         </div>
@@ -53,10 +53,10 @@ export default function QuickGateways() {
                   <IconComponent className="size-6" aria-hidden="true" />
                 </div>
                 <div>
-                  <h3 className="text-lg font-semibold text-[var(--brand-emerald)]">{title}</h3>
-                  <p className="mt-2 text-sm text-[color-mix(in_srgb,var(--brand-emerald)_35%,#05382c_65%)]">{description}</p>
+                  <h3 className="typography-heading-4 font-semibold text-[var(--brand-emerald)]">{title}</h3>
+                  <p className="mt-2 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_35%,#05382c_65%)]">{description}</p>
                 </div>
-                <span className="inline-flex items-center justify-start text-sm font-semibold text-[var(--brand-emerald)] transition group-hover:text-[color-mix(in_srgb,var(--brand-emerald)_70%,#032823_30%)]">
+                <span className="inline-flex items-center justify-start typography-body-sm font-semibold text-[var(--brand-emerald)] transition group-hover:text-[color-mix(in_srgb,var(--brand-emerald)_70%,#032823_30%)]">
                   Explore
                   <svg
                     className="ml-2 size-4 transition group-hover:translate-x-1"

--- a/src/components/TrustedBySchools.jsx
+++ b/src/components/TrustedBySchools.jsx
@@ -18,9 +18,9 @@ export default function TrustedBySchools() {
             <p className="inline-flex items-center gap-2 rounded-full border border-[var(--brand-emerald)]/20 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
               Trusted by schools
             </p>
-            <h2 className="mt-4 text-3xl font-semibold text-[var(--brand-emerald)]">Serving Uganda’s most trusted institutions</h2>
+            <h2 className="mt-4 typography-heading-2 font-semibold text-[var(--brand-emerald)]">Serving Uganda’s most trusted institutions</h2>
           </div>
-          <p className="max-w-xl text-sm text-slate-600">
+          <p className="max-w-xl typography-body-sm text-slate-600">
             From rural diocesan schools to national academies, Skooli powers reliable delivery and transparent reporting.
           </p>
         </div>
@@ -28,7 +28,7 @@ export default function TrustedBySchools() {
           {schools.map((school) => (
             <div
               key={school.name}
-              className="group flex h-24 items-center justify-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 text-center text-sm font-semibold tracking-wide text-slate-500 shadow-sm transition hover:-translate-y-0.5 hover:border-[var(--brand-emerald)] hover:shadow-md"
+              className="group flex h-24 items-center justify-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 text-center typography-body-sm font-semibold tracking-wide text-slate-500 shadow-sm transition hover:-translate-y-0.5 hover:border-[var(--brand-emerald)] hover:shadow-md"
               title={school.tooltip}
             >
               <Shield className="size-4 text-slate-400 transition group-hover:text-[var(--brand-emerald)]" aria-hidden="true" />

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+@import "./styles/tokens.css";
 @import "tailwindcss";
 @import "tw-animate-css";
 

--- a/src/pages/AboutUs.jsx
+++ b/src/pages/AboutUs.jsx
@@ -6,20 +6,20 @@ const AboutUs = () => {
   return (
     <div className="p-8 bg-skooli-cream">
       <div className="max-w-4xl mx-auto">
-        <h1 className="text-4xl font-bold text-emerald-green mb-4">About Skooli</h1>
-        <p className="text-lg text-gray-700 mb-6">
+        <h1 className="typography-heading-1 font-bold text-emerald-green mb-4">About Skooli</h1>
+        <p className="typography-body-lg text-gray-700 mb-6">
           Skooli is a mission-driven organization dedicated to transforming the educational landscape in Africa. We believe that every student deserves access to the resources they need to succeed, and we are committed to making that a reality through innovative technology and strategic partnerships.
         </p>
 
         <div className="mb-8">
-          <h2 className="text-2xl font-semibold text-emerald-green mb-3">Our Mission</h2>
+          <h2 className="typography-heading-3 font-semibold text-emerald-green mb-3">Our Mission</h2>
           <p className="text-gray-700">
             Our mission is to empower students and educators by providing a seamless and efficient platform for accessing educational supplies. We strive to create a sustainable ecosystem that supports local suppliers, strengthens school communities, and fosters a culture of learning.
           </p>
         </div>
 
         <div className="mb-8">
-          <h2 className="text-2xl font-semibold text-emerald-green mb-3">Our Values</h2>
+          <h2 className="typography-heading-3 font-semibold text-emerald-green mb-3">Our Values</h2>
           <ul className="list-disc list-inside text-gray-700 space-y-2">
             <li><strong>Impact:</strong> We are driven by the desire to make a meaningful and lasting impact on the lives of students and educators.</li>
             <li><strong>Innovation:</strong> We are constantly seeking new and better ways to solve the challenges facing the education sector.</li>
@@ -29,7 +29,7 @@ const AboutUs = () => {
         </div>
 
         <div>
-          <h2 className="text-2xl font-semibold text-emerald-green mb-3">Join Us</h2>
+          <h2 className="typography-heading-3 font-semibold text-emerald-green mb-3">Join Us</h2>
           <p className="text-gray-700 mb-4">
             We are always looking for passionate and talented individuals to join our team. If you share our vision for a brighter future for education in Africa, we would love to hear from you.
           </p>

--- a/src/pages/FundersInvestors.jsx
+++ b/src/pages/FundersInvestors.jsx
@@ -113,8 +113,8 @@ export default function FundersInvestors() {
               <AccentPill size="sm" className="tracking-[0.25em]">
                 Investor centre
               </AccentPill>
-              <h1 className="mt-4 text-4xl font-bold text-[var(--brand-emerald)]">Back Africa’s education logistics backbone</h1>
-              <p className="mt-4 max-w-3xl text-base text-slate-600">
+              <h1 className="mt-4 typography-heading-1 font-bold text-[var(--brand-emerald)]">Back Africa’s education logistics backbone</h1>
+              <p className="mt-4 max-w-3xl typography-body-md text-slate-600">
                 Skooli is raising to scale our AI-enabled supply chain, deepen school integrations, and expand to three additional East African markets by 2027.
               </p>
               <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
@@ -128,10 +128,10 @@ export default function FundersInvestors() {
                         <AccentPill size="xs" className="tracking-[0.25em]">
                           {column.title}
                         </AccentPill>
-                        <h2 className="mt-3 text-xl font-semibold text-[var(--brand-emerald)]">{column.highlight}</h2>
-                        <p className="mt-2 text-sm text-slate-600">{column.summary}</p>
+                        <h2 className="mt-3 typography-heading-4 font-semibold text-[var(--brand-emerald)]">{column.highlight}</h2>
+                        <p className="mt-2 typography-body-sm text-slate-600">{column.summary}</p>
                       </div>
-                      <span className="rounded-full bg-[color-mix(in_srgb,var(--brand-emerald)_12%,#ffffff_88%)] px-3 py-1 text-xs font-semibold text-[var(--brand-emerald)]">
+                      <span className="rounded-full bg-[color-mix(in_srgb,var(--brand-emerald)_12%,#ffffff_88%)] px-3 py-1 typography-body-xs font-semibold text-[var(--brand-emerald)]">
                         {column.trend[column.trend.length - 1] > column.trend[0] ? '+Growth' : 'Stable'}
                       </span>
                     </div>
@@ -189,9 +189,9 @@ export default function FundersInvestors() {
           <div className="grid flex-1 gap-6 sm:grid-cols-3">
             {tractionSnapshot.map((item) => (
               <div key={item.label} className="rounded-2xl border border-[var(--brand-emerald)]/15 bg-white/60 p-4 text-center shadow-sm shadow-black/5">
-                <p className="text-sm font-semibold text-[var(--brand-emerald)]">{item.label}</p>
-                <p className="mt-2 text-xl font-bold text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">{item.value}</p>
-                <p className="mt-1 text-xs text-slate-600">{item.detail}</p>
+                <p className="typography-body-sm font-semibold text-[var(--brand-emerald)]">{item.label}</p>
+                <p className="mt-2 typography-heading-4 font-bold text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">{item.value}</p>
+                <p className="mt-1 typography-body-xs text-slate-600">{item.detail}</p>
               </div>
             ))}
           </div>
@@ -202,8 +202,8 @@ export default function FundersInvestors() {
         <div className="mx-auto max-w-6xl px-4">
           <div className="grid gap-8 lg:grid-cols-[1.5fr_1fr] lg:items-start">
             <div>
-              <h2 className="text-3xl font-semibold text-[var(--brand-emerald)]">Financial projections snapshot</h2>
-              <p className="mt-4 text-sm text-slate-600">
+              <h2 className="typography-heading-2 font-semibold text-[var(--brand-emerald)]">Financial projections snapshot</h2>
+              <p className="mt-4 typography-body-sm text-slate-600">
                 Revenue and EBITDA forecasts based on confirmed school contracts and expansion assumptions.
               </p>
               <div className="relative mt-6 overflow-hidden rounded-3xl border border-[var(--brand-emerald)]/15 bg-white/70 p-6 shadow-lg shadow-black/5">
@@ -211,12 +211,12 @@ export default function FundersInvestors() {
                   <div className="rounded-2xl bg-[var(--brand-cream)]/80 p-6">
                     <div className="grid gap-4 sm:grid-cols-3">
                       {projectionData.map((item) => (
-                        <div key={item.year} className="rounded-2xl bg-white p-4 text-sm text-slate-600 shadow">
+                        <div key={item.year} className="rounded-2xl bg-white p-4 typography-body-sm text-slate-600 shadow">
                           <AccentPill size="xs" className="tracking-[0.25em]">
                             {item.year}
                           </AccentPill>
-                          <p className="mt-3 text-lg font-semibold text-[var(--brand-emerald)]">Revenue ${item.revenue.toFixed(1)}M</p>
-                          <p className="text-sm text-emerald-600">EBITDA ${item.ebitda.toFixed(1)}M</p>
+                          <p className="mt-3 typography-heading-4 font-semibold text-[var(--brand-emerald)]">Revenue ${item.revenue.toFixed(1)}M</p>
+                          <p className="typography-body-sm text-emerald-600">EBITDA ${item.ebitda.toFixed(1)}M</p>
                         </div>
                       ))}
                     </div>

--- a/src/pages/MeetTheTeam.jsx
+++ b/src/pages/MeetTheTeam.jsx
@@ -87,8 +87,8 @@ export default function MeetTheTeam() {
           <AccentPill size="sm" className="mx-auto tracking-[0.25em]">
             Meet the team
           </AccentPill>
-          <h1 className="mt-4 text-4xl font-bold text-[var(--brand-emerald)]">Faithful leaders stewarding Skooli’s mission</h1>
-          <p className="mt-4 text-base text-slate-600">
+          <h1 className="mt-4 typography-heading-1 font-bold text-[var(--brand-emerald)]">Faithful leaders stewarding Skooli’s mission</h1>
+          <p className="mt-4 typography-body-md text-slate-600">
             Our team blends logistics, technology, and ministry experience to deliver for learners across Uganda.
           </p>
         </div>
@@ -96,7 +96,7 @@ export default function MeetTheTeam() {
 
       <section className="py-16">
         <div className="mx-auto max-w-6xl px-4">
-          <h2 className="text-3xl font-semibold text-[var(--brand-emerald)]">Founders</h2>
+          <h2 className="typography-heading-2 font-semibold text-[var(--brand-emerald)]">Founders</h2>
           <div className="mt-8 grid gap-6 md:grid-cols-3">
             {founders.map((founder) => (
               <article
@@ -111,24 +111,24 @@ export default function MeetTheTeam() {
                 />
                 <div className="flex flex-1 flex-col p-6">
                   <div>
-                    <h3 className="text-xl font-semibold text-[var(--brand-emerald)]">{founder.name}</h3>
+                    <h3 className="typography-heading-4 font-semibold text-[var(--brand-emerald)]">{founder.name}</h3>
                     <AccentPill size="xs" className="mt-2 tracking-[0.2em]">
                       {founder.role}
                     </AccentPill>
-                    <p className="mt-3 text-sm text-slate-600">{founder.bio}</p>
+                    <p className="mt-3 typography-body-sm text-slate-600">{founder.bio}</p>
                   </div>
-                  <dl className="mt-4 grid gap-3 rounded-2xl bg-[var(--brand-cream)]/70 p-4 text-sm text-[var(--brand-emerald)]">
+                  <dl className="mt-4 grid gap-3 rounded-2xl bg-[var(--brand-cream)]/70 p-4 typography-body-sm text-[var(--brand-emerald)]">
                     {founder.metrics.map((metric) => (
                       <div key={metric.label} className="flex flex-col">
                         <dt className="font-semibold">{metric.value}</dt>
-                        <dd className="text-xs uppercase tracking-[0.3em] text-[var(--brand-emerald)]/70">
+                        <dd className="typography-body-xs uppercase tracking-[0.3em] text-[var(--brand-emerald)]/70">
                           {metric.label}
                         </dd>
                       </div>
                     ))}
                   </dl>
                   <a
-                    className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-md border border-[var(--brand-emerald)] px-4 py-2 text-sm font-semibold text-[var(--brand-emerald)] shadow transition hover:bg-[var(--brand-emerald)] hover:text-white"
+                    className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-md border border-[var(--brand-emerald)] px-4 py-2 typography-body-sm font-semibold text-[var(--brand-emerald)] shadow transition hover:bg-[var(--brand-emerald)] hover:text-white"
                     href={founder.linkedin}
                     target="_blank"
                     rel="noreferrer"
@@ -144,18 +144,18 @@ export default function MeetTheTeam() {
 
       <section className="bg-white py-16">
         <div className="mx-auto max-w-6xl px-4">
-          <h2 className="text-3xl font-semibold text-[var(--brand-emerald)]">Advisors</h2>
+          <h2 className="typography-heading-2 font-semibold text-[var(--brand-emerald)]">Advisors</h2>
           <div className="mt-8 grid gap-6 md:grid-cols-3">
             {advisors.map((advisor) => (
               <div key={advisor.name} className="rounded-3xl bg-[var(--brand-cream)] p-6 shadow-lg shadow-black/5">
-                <h3 className="text-lg font-semibold text-[var(--brand-emerald)]">{advisor.name}</h3>
+                <h3 className="typography-heading-4 font-semibold text-[var(--brand-emerald)]">{advisor.name}</h3>
                 <AccentPill size="xs" className="mt-2 tracking-[0.2em]">
                   {advisor.focus}
                 </AccentPill>
-                <p className="mt-3 text-sm text-slate-600">{advisor.summary}</p>
+                <p className="mt-3 typography-body-sm text-slate-600">{advisor.summary}</p>
                 <div className="mt-4 flex flex-wrap gap-2">
                   {advisor.tags.map((tag) => (
-                    <span key={tag} className="rounded-full bg-white px-3 py-1 text-xs font-semibold text-[var(--brand-emerald)] shadow">
+                    <span key={tag} className="rounded-full bg-white px-3 py-1 typography-body-xs font-semibold text-[var(--brand-emerald)] shadow">
                       {tag}
                     </span>
                   ))}
@@ -168,13 +168,13 @@ export default function MeetTheTeam() {
 
       <section className="py-16">
         <div className="mx-auto max-w-6xl px-4">
-          <h2 className="text-3xl font-semibold text-[var(--brand-emerald)]">Culture values</h2>
+          <h2 className="typography-heading-2 font-semibold text-[var(--brand-emerald)]">Culture values</h2>
           <div className="mt-6 overflow-x-auto">
             <div className="flex gap-4">
               {cultureQuotes.map((item) => (
                 <div key={item.staff} className="min-w-[260px] rounded-3xl bg-white p-6 shadow-lg shadow-black/5">
-                  <p className="text-sm text-slate-600">{item.quote}</p>
-                  <p className="mt-4 text-sm font-semibold text-[var(--brand-emerald)]">{item.staff}</p>
+                  <p className="typography-body-sm text-slate-600">{item.quote}</p>
+                  <p className="mt-4 typography-body-sm font-semibold text-[var(--brand-emerald)]">{item.staff}</p>
                 </div>
               ))}
             </div>

--- a/src/pages/PartnerInquiry.jsx
+++ b/src/pages/PartnerInquiry.jsx
@@ -21,10 +21,10 @@ export default function PartnerInquiry() {
           <AccentPill tone="inverse" className="bg-white/15">
             Partner Inquiry
           </AccentPill>
-          <h1 className="mt-4 text-4xl font-bold leading-tight text-[var(--brand-emerald)] sm:text-5xl">
+          <h1 className="mt-4 typography-heading-1 font-bold leading-tight text-[var(--brand-emerald)]">
             Let's build something great together
           </h1>
-          <p className="mt-4 max-w-3xl text-base text-[var(--brand-emerald)]">
+          <p className="mt-4 max-w-3xl typography-body-md text-[var(--brand-emerald)]">
             Tell us about your organization and how you'd like to collaborate. A partnership lead will respond within 48 hours.
           </p>
         </div>

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,82 @@
+:root {
+  --font-family-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+  --font-size-display: clamp(2.75rem, 1.25rem + 4vw, 4rem);
+  --font-size-h1: clamp(2.25rem, 1.1rem + 2.5vw, 3.25rem);
+  --font-size-h2: clamp(2rem, 1rem + 2vw, 2.75rem);
+  --font-size-h3: clamp(1.75rem, 0.9rem + 1.5vw, 2.25rem);
+  --font-size-h4: clamp(1.5rem, 0.75rem + 1.2vw, 1.75rem);
+  --font-size-body-lg: 1.25rem;
+  --font-size-body-md: 1rem;
+  --font-size-body-sm: 0.875rem;
+  --font-size-body-xs: 0.75rem;
+
+  --line-height-tight: 1.1;
+  --line-height-snug: 1.25;
+  --line-height-relaxed: 1.4;
+  --line-height-body: 1.6;
+}
+
+body {
+  font-family: var(--font-family-sans);
+}
+
+.typography-display {
+  font-size: var(--font-size-display);
+  line-height: var(--line-height-tight);
+  letter-spacing: -0.015em;
+}
+
+.typography-heading-1,
+h1,
+.h1 {
+  font-size: var(--font-size-h1);
+  line-height: var(--line-height-tight);
+  letter-spacing: -0.01em;
+}
+
+.typography-heading-2,
+h2,
+.h2 {
+  font-size: var(--font-size-h2);
+  line-height: var(--line-height-snug);
+  letter-spacing: -0.01em;
+}
+
+.typography-heading-3,
+h3,
+.h3 {
+  font-size: var(--font-size-h3);
+  line-height: var(--line-height-snug);
+}
+
+.typography-heading-4,
+h4,
+.h4 {
+  font-size: var(--font-size-h4);
+  line-height: var(--line-height-relaxed);
+}
+
+.typography-body-lg {
+  font-size: var(--font-size-body-lg);
+  line-height: var(--line-height-body);
+}
+
+.typography-body-md,
+p,
+.body-md {
+  font-size: var(--font-size-body-md);
+  line-height: var(--line-height-body);
+}
+
+.typography-body-sm,
+.body-sm {
+  font-size: var(--font-size-body-sm);
+  line-height: var(--line-height-body);
+}
+
+.typography-body-xs,
+.body-xs {
+  font-size: var(--font-size-body-xs);
+  line-height: var(--line-height-relaxed);
+}


### PR DESCRIPTION
## Summary
- add a shared typography token file with custom properties and reusable type scale helpers
- import the new tokens into the global stylesheet and update hero, marketing, and footer components to consume them
- refactor representative marketing pages to rely on the shared typography classes instead of ad-hoc Tailwind sizing

## Testing
- pnpm build *(fails: local pnpm store is missing the Vite binary in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6902c1918d20832baaf57130fafa3260