### PR TITLE
Refactor palette tokens and align UI colors with CSS variables

### DIFF
--- a/src/components/AccentPill.jsx
+++ b/src/components/AccentPill.jsx
@@ -2,15 +2,15 @@ import { cn } from '@/lib/utils.js'
 
 const toneStyles = {
   emerald: {
-    text: 'text-[color-mix(in_srgb,var(--brand-emerald)_88%,#032823_12%)]',
+    text: 'text-[color-mix(in_srgb,var(--brand-emerald)_88%,var(--emerald-ink)_12%)]',
     border: 'border-[var(--brand-emerald)]/20',
-    background: 'bg-[color-mix(in_srgb,var(--brand-cream)_72%,#ffffff_28%)]',
+    background: 'bg-[color-mix(in_srgb,var(--brand-cream)_72%,var(--brand-white)_28%)]',
     shadow: 'shadow-white/60',
   },
   inverse: {
-    text: 'text-white',
-    border: 'border-white/30',
-    background: 'bg-white/10',
+    text: 'text-[var(--brand-white)]',
+    border: 'border-[color-mix(in_srgb,var(--brand-white)_30%,transparent)]',
+    background: 'bg-[color-mix(in_srgb,var(--brand-white)_10%,transparent)]',
     shadow: 'shadow-black/20',
   },
 }

--- a/src/components/ComplianceKit.jsx
+++ b/src/components/ComplianceKit.jsx
@@ -30,30 +30,30 @@ export default function ComplianceKit({
   documents = defaultDocuments,
 }) {
   return (
-    <div className={cn('rounded-3xl bg-white p-6 shadow-lg shadow-black/5', className)}>
+    <div className={cn('rounded-3xl bg-[var(--brand-white)] p-6 shadow-lg shadow-black/5', className)}>
       <AccentPill size="sm" className="tracking-[0.25em]">
         {title}
       </AccentPill>
-      <p className="mt-3 typography-body-sm text-slate-600">{blurb}</p>
+      <p className="mt-3 typography-body-sm text-[var(--emerald-bough)]">{blurb}</p>
       <ul className="mt-6 space-y-4">
         {documents.map((document) => {
           const Icon = document.icon
           return (
-            <li key={document.title} className="flex flex-col gap-2 rounded-2xl border border-[var(--brand-emerald)]/10 bg-[var(--brand-cream)]/40 p-4 transition hover:border-[color-mix(in_srgb,var(--brand-emerald)_70%,#032823_30%)]/40">
+            <li key={document.title} className="flex flex-col gap-2 rounded-2xl border border-[var(--brand-emerald)]/10 bg-[var(--brand-cream)]/40 p-4 transition hover:border-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--emerald-ink)_30%)]/40">
               <div className="flex items-start gap-3">
                 <span className="flex size-9 items-center justify-center rounded-full bg-[var(--brand-emerald)]/10 text-[var(--brand-emerald)]">
                   <Icon className="size-4" aria-hidden="true" />
                 </span>
                 <div>
                   <p className="typography-body-sm font-semibold text-[var(--brand-emerald)]">{document.title}</p>
-                  <p className="typography-body-xs text-slate-600">{document.description}</p>
+                  <p className="typography-body-xs text-[var(--emerald-bough)]">{document.description}</p>
                 </div>
               </div>
               <div>
                 <a
                   href={document.href}
                   download
-                  className="inline-flex items-center gap-2 typography-body-xs font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] underline decoration-[color-mix(in_srgb,var(--brand-emerald)_45%,#032823_55%)] decoration-2 underline-offset-4 hover:text-[var(--brand-emerald)]"
+                  className="inline-flex items-center gap-2 typography-body-xs font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)] underline decoration-[color-mix(in_srgb,var(--brand-emerald)_45%,var(--emerald-ink)_55%)] decoration-2 underline-offset-4 hover:text-[var(--brand-emerald)]"
                 >
                   Download template
                   <FileDown className="size-3" aria-hidden="true" />

--- a/src/components/ExpansionJourney.jsx
+++ b/src/components/ExpansionJourney.jsx
@@ -2,12 +2,12 @@ const expansionMapFallback = `data:image/svg+xml;utf8,${encodeURIComponent(
   `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800'>
       <defs>
         <linearGradient id='expansionGradient' x1='0%' y1='0%' x2='100%' y2='100%'>
-          <stop offset='0%' stop-color='#009877'/>
-          <stop offset='100%' stop-color='rgba(0,152,119,0)'/>
+          <stop offset='0%' stop-color='var(--brand-emerald)'/>
+          <stop offset='100%' stop-color='rgba(0,0,0,0)'/>
         </linearGradient>
       </defs>
       <rect width='1200' height='800' fill='url(#expansionGradient)' />
-      <text x='50%' y='50%' font-family='Inter, Arial, sans-serif' font-size='42' fill='#ffffff' text-anchor='middle'>
+      <text x='50%' y='50%' font-family='Inter, Arial, sans-serif' font-size='42' fill='var(--brand-white)' text-anchor='middle'>
         Upload skooli_african_map.png to public/assets/branding
       </text>
     </svg>`
@@ -16,9 +16,9 @@ const expansionMapFallback = `data:image/svg+xml;utf8,${encodeURIComponent(
 const expansionMapSrc = '/assets/branding/skooli_african_map.png'
 
 const legendItems = [
-  { name: 'Pilot districts (Uganda)', background: 'rgba(255, 215, 0, 0.85)', border: 'rgba(255,255,255,0.25)' },
-  { name: 'Scale-ready hubs (Kenya)', background: 'rgba(0,152,119,0.65)', border: 'rgba(255,255,255,0.25)' },
-  { name: 'Expansion markets (Ghana)', background: 'rgba(252,230,174,0.75)', border: 'rgba(255,255,255,0.4)' },
+  { name: 'Pilot districts (Uganda)', background: 'color-mix(in srgb, var(--brand-gold) 85%, transparent)', border: 'color-mix(in srgb, var(--brand-white) 25%, transparent)' },
+  { name: 'Scale-ready hubs (Kenya)', background: 'color-mix(in srgb, var(--brand-emerald) 65%, transparent)', border: 'color-mix(in srgb, var(--brand-white) 25%, transparent)' },
+  { name: 'Expansion markets (Ghana)', background: 'color-mix(in srgb, var(--brand-cream) 75%, transparent)', border: 'color-mix(in srgb, var(--brand-white) 40%, transparent)' },
 ]
 
 import { AccentPill } from '@/components/AccentPill.jsx'
@@ -52,7 +52,7 @@ const handleMapError = (event) => {
 
 export default function ExpansionJourney() {
   return (
-    <section className="bg-[color-mix(in_srgb,var(--brand-emerald)_70%,#000_30%)] py-16 text-white sm:py-20" id="expansion-journey">
+    <section className="bg-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--neutral-black)_30%)] py-16 text-white sm:py-20" id="expansion-journey">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 items-center gap-12 md:grid-cols-2 lg:grid-cols-2">
           <div className="flex flex-col justify-center">

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -32,11 +32,11 @@ const footerSections = {
 
 export default function Footer() {
   return (
-    <footer className="relative overflow-hidden text-[color-mix(in_srgb,var(--brand-emerald)_88%,#032823_12%)]">
+    <footer className="relative overflow-hidden text-[color-mix(in_srgb,var(--brand-emerald)_88%,var(--emerald-ink)_12%)]">
       <div
         className="absolute inset-0"
         style={{
-          backgroundImage: `linear-gradient(135deg, rgba(255,255,255,0.95), rgba(252,230,174,0.88)), url(${leadershipPortrait})`,
+          backgroundImage: `linear-gradient(135deg, color-mix(in srgb, var(--brand-white) 95%, transparent), color-mix(in srgb, var(--brand-cream) 88%, transparent)), url(${leadershipPortrait})`,
           backgroundSize: 'cover',
           backgroundPosition: 'center',
         }}
@@ -50,12 +50,12 @@ export default function Footer() {
           <div className="space-y-6">
             <div>
               <h2 className="typography-heading-3 font-bold text-[var(--brand-emerald)]">Skooli</h2>
-              <p className="mt-4 max-w-xs typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
+              <p className="mt-4 max-w-xs typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,var(--emerald-ink)_22%)]">
                 Education logistics built for every Ugandan learner. Ethically sourced.
                 Efficiently delivered. Faithfully stewarded.
               </p>
             </div>
-            <div className="space-y-4 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
+            <div className="space-y-4 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,var(--emerald-ink)_22%)]">
               <div className="flex items-start gap-3">
                 <MapPin className="mt-0.5 size-5 text-[var(--brand-emerald)]" />
                 <div>
@@ -74,20 +74,20 @@ export default function Footer() {
               </div>
               <div className="flex items-center gap-3">
                 <Mail className="size-5 text-[var(--brand-emerald)]" />
-                <a className="typography-body-sm font-semibold text-[var(--brand-emerald)] transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]" href="mailto:hello@skooli.africa">
+                <a className="typography-body-sm font-semibold text-[var(--brand-emerald)] transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)]" href="mailto:hello@skooli.africa">
                   hello@skooli.africa
                 </a>
               </div>
               <div className="flex items-center gap-3">
                 <Phone className="size-5 text-[var(--brand-emerald)]" />
-                <a className="typography-body-sm font-semibold text-[var(--brand-emerald)] transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]" href="tel:+256414000000">
+                <a className="typography-body-sm font-semibold text-[var(--brand-emerald)] transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)]" href="tel:+256414000000">
                   +256 414 000 000
                 </a>
               </div>
             </div>
             <div className="flex gap-3">
               <a
-                className="flex size-10 items-center justify-center rounded-full border border-[var(--brand-emerald)]/20 bg-white text-[var(--brand-emerald)] shadow-sm transition hover:-translate-y-0.5 hover:bg-[var(--brand-emerald)] hover:text-white"
+                className="flex size-10 items-center justify-center rounded-full border border-[var(--brand-emerald)]/20 bg-[var(--brand-white)] text-[var(--brand-emerald)] shadow-sm transition hover:-translate-y-0.5 hover:bg-[var(--brand-emerald)] hover:text-[var(--brand-white)]"
                 href="https://www.linkedin.com/company/skooli"
                 target="_blank"
                 rel="noreferrer"
@@ -96,7 +96,7 @@ export default function Footer() {
                 <Linkedin className="size-5" />
               </a>
               <a
-                className="flex size-10 items-center justify-center rounded-full border border-[var(--brand-emerald)]/20 bg-white text-[var(--brand-emerald)] shadow-sm transition hover:-translate-y-0.5 hover:bg-[var(--brand-emerald)] hover:text-white"
+                className="flex size-10 items-center justify-center rounded-full border border-[var(--brand-emerald)]/20 bg-[var(--brand-white)] text-[var(--brand-emerald)] shadow-sm transition hover:-translate-y-0.5 hover:bg-[var(--brand-emerald)] hover:text-[var(--brand-white)]"
                 href="https://twitter.com/skooli_africa"
                 target="_blank"
                 rel="noreferrer"
@@ -105,7 +105,7 @@ export default function Footer() {
                 <Twitter className="size-5" />
               </a>
               <a
-                className="flex size-10 items-center justify-center rounded-full border border-[var(--brand-emerald)]/20 bg-white text-[var(--brand-emerald)] shadow-sm transition hover:-translate-y-0.5 hover:bg-[var(--brand-emerald)] hover:text-white"
+                className="flex size-10 items-center justify-center rounded-full border border-[var(--brand-emerald)]/20 bg-[var(--brand-white)] text-[var(--brand-emerald)] shadow-sm transition hover:-translate-y-0.5 hover:bg-[var(--brand-emerald)] hover:text-[var(--brand-white)]"
                 href="https://www.youtube.com/@skooli"
                 target="_blank"
                 rel="noreferrer"
@@ -118,7 +118,7 @@ export default function Footer() {
 
           <div>
             <h3 className="typography-heading-4 font-semibold text-[var(--brand-emerald)]">Company</h3>
-            <ul className="mt-6 space-y-3 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
+            <ul className="mt-6 space-y-3 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,var(--emerald-ink)_22%)]">
               {footerSections.company.map((item) => (
                 <li key={item.label}>
                   <Link className="transition hover:text-[var(--brand-emerald)]" to={item.to}>
@@ -131,7 +131,7 @@ export default function Footer() {
 
           <div>
             <h3 className="typography-heading-4 font-semibold text-[var(--brand-emerald)]">Services</h3>
-            <ul className="mt-6 space-y-3 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
+            <ul className="mt-6 space-y-3 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,var(--emerald-ink)_22%)]">
               {footerSections.services.map((item) => (
                 <li key={item.label}>
                   <Link className="transition hover:text-[var(--brand-emerald)]" to={item.to}>
@@ -144,7 +144,7 @@ export default function Footer() {
 
           <div>
             <h3 className="typography-heading-4 font-semibold text-[var(--brand-emerald)]">Resources & Legal</h3>
-            <ul className="mt-6 space-y-3 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,#032823_22%)]">
+            <ul className="mt-6 space-y-3 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,var(--emerald-ink)_22%)]">
               {[...footerSections.resources, ...footerSections.legal].map((item) => (
                 <li key={item.label}>
                   <Link className="transition hover:text-[var(--brand-emerald)]" to={item.to}>
@@ -153,9 +153,9 @@ export default function Footer() {
                 </li>
               ))}
             </ul>
-            <div className="mt-8 space-y-3 rounded-2xl border border-[var(--brand-emerald)]/15 bg-[color-mix(in_srgb,var(--brand-cream)_75%,#ffffff_25%)] p-4 shadow-sm">
+            <div className="mt-8 space-y-3 rounded-2xl border border-[var(--brand-emerald)]/15 bg-[color-mix(in_srgb,var(--brand-cream)_75%,var(--brand-white)_25%)] p-4 shadow-sm">
               <p className="typography-body-sm font-semibold text-[var(--brand-emerald)]">Stay in the loop</p>
-              <p className="typography-body-xs text-[color-mix(in_srgb,var(--brand-emerald)_70%,#4c625b_30%)]">Monthly executive briefings on logistics, impact and technology.</p>
+              <p className="typography-body-xs text-[color-mix(in_srgb,var(--brand-emerald)_60%,var(--emerald-ink)_40%)]">Monthly executive briefings on logistics, impact and technology.</p>
               <form
                 className="flex items-center gap-2"
                 onSubmit={(event) => {
@@ -169,7 +169,7 @@ export default function Footer() {
                 }}
               >
                 <input
-                  className="h-10 flex-1 rounded-full border border-[var(--brand-emerald)]/25 bg-white px-3 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)] placeholder:text-[color-mix(in_srgb,var(--brand-emerald)_45%,#8da49a_55%)] focus:border-[var(--brand-emerald)] focus:outline-none"
+                  className="h-10 flex-1 rounded-full border border-[var(--brand-emerald)]/25 bg-[var(--brand-white)] px-3 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_80%,var(--emerald-ink)_20%)] placeholder:text-[color-mix(in_srgb,var(--brand-emerald)_45%,var(--emerald-haze)_55%)] focus:border-[var(--brand-emerald)] focus:outline-none"
                   type="email"
                   name="email"
                   aria-label="Email for newsletter"
@@ -178,7 +178,7 @@ export default function Footer() {
                 />
                 <button
                   type="submit"
-                  className="flex h-10 items-center justify-center rounded-full bg-[var(--brand-emerald)] px-4 typography-body-sm font-semibold text-white shadow-sm shadow-black/10 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]"
+                  className="flex h-10 items-center justify-center rounded-full bg-[var(--brand-emerald)] px-4 typography-body-sm font-semibold text-[var(--brand-white)] shadow-sm shadow-black/10 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)]"
                 >
                   <Send className="size-4" />
                 </button>
@@ -187,7 +187,7 @@ export default function Footer() {
           </div>
         </div>
         <div className="mt-12 border-t border-[var(--brand-emerald)]/20 pt-6">
-          <div className="flex flex-col gap-4 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_72%,#032823_28%)] md:flex-row md:items-center md:justify-between">
+          <div className="flex flex-col gap-4 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_72%,var(--emerald-ink)_28%)] md:flex-row md:items-center md:justify-between">
             <p>© {new Date().getFullYear()} Skooli Technologies Group Ltd. All rights reserved.</p>
             <div className="flex items-center gap-2">
               <span>Made with</span>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -7,12 +7,12 @@ const heroFallback = `data:image/svg+xml;utf8,${encodeURIComponent(
   `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 800'>
       <defs>
         <linearGradient id='g' x1='0%' y1='0%' x2='100%' y2='100%'>
-          <stop offset='0%' stop-color='#009877'/>
-          <stop offset='100%' stop-color='rgba(0,152,119,0)'/>
+          <stop offset='0%' stop-color='var(--brand-emerald)'/>
+          <stop offset='100%' stop-color='rgba(0,0,0,0)'/>
         </linearGradient>
       </defs>
       <rect width='1200' height='800' fill='url(#g)' />
-      <text x='50%' y='50%' font-family='Inter, Arial, sans-serif' font-size='42' fill='#ffffff' text-anchor='middle'>
+      <text x='50%' y='50%' font-family='Inter, Arial, sans-serif' font-size='42' fill='var(--brand-white)' text-anchor='middle'>
         Upload skooli_banner_image.jpg to public/assets/branding
       </text>
     </svg>`
@@ -45,25 +45,25 @@ export default function Hero() {
           />
         </picture>
         <div
-          className="absolute inset-0 bg-gradient-to-r from-[rgba(0,152,119,0.85)] via-[rgba(2,45,36,0.65)] to-transparent"
+          className="absolute inset-0 bg-gradient-to-r from-[color-mix(in_srgb,var(--brand-emerald)_85%,transparent)] via-[color-mix(in_srgb,var(--emerald-ink)_65%,transparent)] to-transparent"
           aria-hidden="true"
         />
       </div>
-      <div className="relative z-10 mx-auto max-w-7xl px-4 py-24 text-left text-white sm:px-6 lg:px-8">
+      <div className="relative z-10 mx-auto max-w-7xl px-4 py-24 text-left text-[var(--brand-white)] sm:px-6 lg:px-8">
         <div className="max-w-2xl">
-          <AccentPill tone="inverse" size="sm" className="bg-white/20">
+          <AccentPill tone="inverse" size="sm" className="bg-[color-mix(in_srgb,var(--brand-white)_20%,transparent)]">
             Executive briefing
           </AccentPill>
-          <h1 className="mt-6 typography-display font-semibold text-white">
+          <h1 className="mt-6 typography-display font-semibold text-[var(--brand-white)]">
             Operational assurance for national education pilots
           </h1>
-          <p className="mt-6 typography-body-lg font-medium text-white/90">
+          <p className="mt-6 typography-body-lg font-medium text-[color-mix(in_srgb,var(--brand-white)_90%,transparent)]">
             Skooli deploys accountable facilitators, verified suppliers, and transparent financial rails so ministries see auditable results from the first cohort through national scale.
           </p>
           <div className="mt-10">
             <Button
               size="lg"
-              className="rounded-md bg-[var(--brand-emerald)] px-8 py-4 text-base font-semibold text-white shadow-lg shadow-black/10 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]"
+              className="rounded-md bg-[var(--brand-emerald)] px-8 py-4 text-base font-semibold text-[var(--brand-white)] shadow-lg shadow-black/10 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_80%,var(--emerald-ink)_20%)]"
               asChild
             >
               <Link to="/downloads/skooli-impact-report-2025.pdf" target="_blank" rel="noreferrer noopener">

--- a/src/components/HeroStats.jsx
+++ b/src/components/HeroStats.jsx
@@ -7,12 +7,12 @@ export default function HeroStats() {
   return (
     <section className="-mt-10 bg-transparent pb-6">
       <div className="mx-auto max-w-6xl px-4">
-        <div className="grid gap-4 rounded-2xl bg-white/95 p-4 shadow-xl shadow-black/5 backdrop-blur sm:grid-cols-3">
+        <div className="grid gap-4 rounded-2xl bg-[color-mix(in_srgb,var(--brand-white)_95%,transparent)] p-4 shadow-xl shadow-black/5 backdrop-blur sm:grid-cols-3">
           {items.map((item) => (
             <div key={item.label} className="flex items-center justify-center rounded-xl p-4 text-center">
               <div>
                 <p className="typography-heading-3 font-bold text-[var(--brand-emerald)]">{item.value}</p>
-                <p className="mt-1 typography-body-sm font-medium text-[color-mix(in_srgb,var(--brand-emerald)_25%,#05382c_75%)]">
+                <p className="mt-1 typography-body-sm font-medium text-[color-mix(in_srgb,var(--brand-emerald)_25%,var(--emerald-canopy)_75%)]">
                   {item.label}
                 </p>
               </div>

--- a/src/components/HowItWorksPreview.jsx
+++ b/src/components/HowItWorksPreview.jsx
@@ -22,7 +22,7 @@ const steps = [
 
 export default function HowItWorksPreview() {
   return (
-    <section className="bg-white py-16" id="how-it-works-preview">
+    <section className="bg-[var(--brand-white)] py-16" id="how-it-works-preview">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="flex flex-col items-start justify-between gap-8 md:flex-row md:items-end">
           <div>
@@ -33,7 +33,7 @@ export default function HowItWorksPreview() {
           </div>
           <Link
             to="/how-it-works"
-            className="typography-body-sm font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] transition hover:text-[var(--brand-emerald)]"
+            className="typography-body-sm font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)] transition hover:text-[var(--brand-emerald)]"
           >
             Explore the full playbook →
           </Link>
@@ -46,12 +46,12 @@ export default function HowItWorksPreview() {
                 key={title}
                 className="rounded-2xl bg-[var(--brand-cream)] p-8 shadow-lg shadow-black/5 transition hover:-translate-y-1 hover:shadow-xl"
               >
-                <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-white text-[var(--brand-emerald)] shadow-md">
+                <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-[var(--brand-white)] text-[var(--brand-emerald)] shadow-md">
                   <StepIcon className="size-6" aria-hidden="true" />
                 </div>
-                <p className="mt-4 text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Step {index + 1}</p>
+                <p className="mt-4 text-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--emerald-bough)_45%,var(--emerald-mist)_55%)]">Step {index + 1}</p>
                 <h3 className="mt-2 typography-heading-4 font-semibold text-[var(--brand-emerald)]">{title}</h3>
-                <p className="mt-2 typography-body-sm text-slate-600">{description}</p>
+                <p className="mt-2 typography-body-sm text-[color-mix(in_srgb,var(--emerald-bough)_65%,var(--emerald-mist)_35%)]">{description}</p>
               </div>
             )
           })}

--- a/src/components/ImpactSnapshot.jsx
+++ b/src/components/ImpactSnapshot.jsx
@@ -32,18 +32,18 @@ export default function ImpactSnapshot() {
   }, [])
 
   return (
-    <section className="bg-gradient-to-br from-[var(--brand-emerald)] to-[color-mix(in_srgb,var(--brand-emerald)_70%,#000_30%)] py-16 text-white" id="impact">
+    <section className="bg-gradient-to-br from-[var(--brand-emerald)] to-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--neutral-black)_30%)] py-16 text-[var(--brand-white)]" id="impact">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="flex flex-col gap-8 md:flex-row md:items-center md:justify-between">
           <div>
-            <AccentPill tone="inverse" size="sm" className="bg-white/25">
+            <AccentPill tone="inverse" size="sm" className="bg-[var(--brand-white)]/25">
               Executive Dashboard Sync
             </AccentPill>
-            <p className="mt-6 typography-body-sm font-semibold uppercase tracking-[0.3em] text-white/70">Impact snapshot</p>
+            <p className="mt-6 typography-body-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-white)]/70">Impact snapshot</p>
             <h2 className="mt-4 typography-heading-2 font-semibold">
               Real-time mission metrics from our executive dashboard
             </h2>
-            <p className="mt-4 max-w-xl typography-body-sm text-white/80">
+            <p className="mt-4 max-w-xl typography-body-sm text-[var(--brand-white)]/80">
               Figures sync hourly from our internal CMS—giving partners and investors visibility into performance and promises delivered.
             </p>
             <div className="mt-6 flex flex-wrap items-center gap-4">
@@ -51,7 +51,7 @@ export default function ImpactSnapshot() {
                 href="/downloads/skooli-impact-report-2025.pdf"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center rounded-full bg-white px-5 py-3 typography-body-sm font-semibold text-[var(--brand-emerald)] shadow-lg shadow-black/20 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_12%,#ffffff_88%)] hover:text-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]"
+                className="inline-flex items-center rounded-full bg-[var(--brand-white)] px-5 py-3 typography-body-sm font-semibold text-[var(--brand-emerald)] shadow-lg shadow-black/20 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_12%,var(--brand-white)_88%)] hover:text-[color-mix(in_srgb,var(--brand-emerald)_80%,var(--emerald-ink)_20%)]"
               >
                 Download the executive impact briefing (PDF)
               </a>
@@ -59,14 +59,14 @@ export default function ImpactSnapshot() {
                 href="/downloads/skooli-unit-economics-2025.pdf"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center rounded-full border border-white/30 px-5 py-3 typography-body-sm font-semibold text-white transition hover:-translate-y-0.5 hover:border-white hover:bg-white/10"
+                className="inline-flex items-center rounded-full border border-white/30 px-5 py-3 typography-body-sm font-semibold text-[var(--brand-white)] transition hover:-translate-y-0.5 hover:border-white hover:bg-[var(--brand-white)]/10"
               >
                 View unit economics supplement (PDF)
               </a>
             </div>
           </div>
-          <div className="rounded-2xl border border-white/20 bg-white/10 p-6 shadow-lg shadow-black/10 backdrop-blur">
-            <p className="typography-body-sm font-semibold uppercase tracking-[0.3em] text-white/70">Updated</p>
+          <div className="rounded-2xl border border-white/20 bg-[var(--brand-white)]/10 p-6 shadow-lg shadow-black/10 backdrop-blur">
+            <p className="typography-body-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-white)]/70">Updated</p>
             <p className="typography-heading-3 font-semibold">29 Jan 2025 • 14:00 EAT</p>
           </div>
         </div>
@@ -80,14 +80,14 @@ export default function ImpactSnapshot() {
             return (
               <div
                 key={label}
-                className="rounded-2xl border border-white/15 bg-white/10 p-8 text-center shadow-lg shadow-black/15 backdrop-blur transition hover:bg-white/15"
+                className="rounded-2xl border border-white/15 bg-[var(--brand-white)]/10 p-8 text-center shadow-lg shadow-black/15 backdrop-blur transition hover:bg-[var(--brand-white)]/15"
               >
-                <p className="typography-body-sm font-semibold uppercase tracking-[0.3em] text-white/70">{label}</p>
+                <p className="typography-body-sm font-semibold uppercase tracking-[0.3em] text-[var(--brand-white)]/70">{label}</p>
                 <p className="mt-4 typography-heading-1 font-bold">
                   {displayValue.toLocaleString()}
                   {suffix || ''}
                 </p>
-                <p className="mt-2 typography-body-sm text-white/80">Live counter powered by Sanity CMS</p>
+                <p className="mt-2 typography-body-sm text-[var(--brand-white)]/80">Live counter powered by Sanity CMS</p>
               </div>
             )
           })}

--- a/src/components/NewsletterCTA.jsx
+++ b/src/components/NewsletterCTA.jsx
@@ -5,20 +5,20 @@ export default function NewsletterCTA() {
   return (
     <section className="bg-white py-16" id="newsletter">
       <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-        <div className="rounded-3xl bg-gradient-to-br from-white via-[var(--brand-cream)] to-[color-mix(in_srgb,var(--brand-emerald)_12%,#ffffff_88%)] p-10 shadow-xl shadow-black/10 sm:p-16">
+        <div className="rounded-3xl bg-gradient-to-br from-[var(--brand-white)] via-[var(--brand-cream)] to-[color-mix(in_srgb,var(--brand-emerald)_12%,var(--brand-white)_88%)] p-10 shadow-xl shadow-black/10 sm:p-16">
           <div className="flex flex-col gap-8">
             <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
               <div className="max-w-2xl">
-                <span className="inline-flex items-center rounded-full bg-[color-mix(in_srgb,var(--brand-emerald)_10%,#ffffff_90%)] px-4 py-2 typography-body-xs font-semibold uppercase tracking-[0.3em] text-[var(--brand-emerald)] shadow-inner shadow-white">
+                <span className="inline-flex items-center rounded-full bg-[color-mix(in_srgb,var(--brand-emerald)_10%,var(--brand-white)_90%)] px-4 py-2 typography-body-xs font-semibold uppercase tracking-[0.3em] text-[var(--brand-emerald)] shadow-inner shadow-white">
                   Executive Dashboard Sync
                 </span>
-                <p className="mt-4 inline-flex items-center gap-2 rounded-full border border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_75%,#ffffff_25%)] px-3 py-1 typography-body-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
+                <p className="mt-4 inline-flex items-center gap-2 rounded-full border border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_75%,var(--brand-white)_25%)] px-3 py-1 typography-body-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)]">
                   Newsletter
                 </p>
-                <h2 className="mt-4 typography-heading-2 font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_88%,#032823_12%)]">
+                <h2 className="mt-4 typography-heading-2 font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_88%,var(--emerald-ink)_12%)]">
                   Executive updates delivered monthly
                 </h2>
-                <p className="mt-3 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_35%,#05382c_65%)]">
+                <p className="mt-3 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_35%,var(--emerald-canopy)_65%)]">
                   Subscribe for Mailchimp briefings on impact milestones, product launches, and treasury notes. Every confirmation email now includes the latest PDF dashboard sync for your leadership team.
                 </p>
               </div>
@@ -28,19 +28,19 @@ export default function NewsletterCTA() {
             <div className="rounded-3xl border border-[var(--brand-emerald)]/15 bg-white/70 p-6">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div>
-                  <p className="inline-flex items-center gap-2 rounded-full border border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_70%,#ffffff_30%)] px-3 py-1 typography-body-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
+                  <p className="inline-flex items-center gap-2 rounded-full border border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_70%,var(--brand-white)_30%)] px-3 py-1 typography-body-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)]">
                     Impact Insights
                   </p>
                   <h3 className="mt-2 typography-heading-4 font-semibold text-[var(--brand-emerald)]">Operational highlights from the latest quarter</h3>
                 </div>
-                <span className="rounded-full border border-[var(--brand-emerald)]/15 bg-[color-mix(in_srgb,var(--brand-emerald)_8%,#ffffff_92%)] px-4 py-1 typography-body-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
+                <span className="rounded-full border border-[var(--brand-emerald)]/15 bg-[color-mix(in_srgb,var(--brand-emerald)_8%,var(--brand-white)_92%)] px-4 py-1 typography-body-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)]">
                   Q3 2025
                 </span>
               </div>
               <div className="mt-6 grid gap-4 sm:grid-cols-3">
                 {impactInsights.map((item) => (
-                  <div key={item.label} className="rounded-2xl border border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_65%,#ffffff_35%)] p-4">
-                    <p className="typography-body-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">{item.label}</p>
+                  <div key={item.label} className="rounded-2xl border border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_65%,var(--brand-white)_35%)] p-4">
+                    <p className="typography-body-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)]">{item.label}</p>
                     <p className="mt-3 typography-heading-3 font-bold text-[var(--brand-emerald)]">{item.metric}</p>
                     <p className="mt-2 typography-body-xs text-slate-600">{item.detail}</p>
                   </div>

--- a/src/components/NewsletterSignupModule.jsx
+++ b/src/components/NewsletterSignupModule.jsx
@@ -32,14 +32,14 @@ export function NewsletterSignupModule({ layout = 'horizontal', includeDownloadL
           value={email}
           onChange={(event) => setEmail(event.target.value)}
           placeholder="you@organisation.com"
-          className={`h-12 flex-1 rounded-full border border-[color-mix(in_srgb,var(--brand-emerald)_25%,#ffffff)] bg-white px-4 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_75%,#05382c_25%)] placeholder:text-[color-mix(in_srgb,var(--brand-emerald)_35%,#8b9f99_65%)] focus:border-[var(--brand-emerald)] focus:outline-none ${
+          className={`h-12 flex-1 rounded-full border border-[color-mix(in_srgb,var(--brand-emerald)_25%,var(--brand-white))] bg-[var(--brand-white)] px-4 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_75%,var(--emerald-canopy)_25%)] placeholder:text-[color-mix(in_srgb,var(--brand-emerald)_40%,var(--emerald-bough)_60%)] focus:border-[var(--brand-emerald)] focus:outline-none ${
             isHorizontal ? '' : 'w-full'
           }`}
           aria-label="Email address"
         />
         <button
           type="submit"
-          className="flex h-12 items-center justify-center rounded-full bg-[var(--brand-emerald)] px-6 typography-body-sm font-semibold text-white shadow-lg shadow-black/15 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)] whitespace-nowrap"
+          className="flex h-12 items-center justify-center rounded-full bg-[var(--brand-emerald)] px-6 typography-body-sm font-semibold text-[var(--brand-white)] shadow-lg shadow-black/15 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)] whitespace-nowrap"
           disabled={status === 'loading'}
         >
           {status === 'loading' ? 'Delivering…' : status === 'success' ? 'Briefing Sent!' : 'Send briefing PDF'}
@@ -51,7 +51,7 @@ export function NewsletterSignupModule({ layout = 'horizontal', includeDownloadL
           href="/downloads/skooli-pitch-deck-q3-2025.pdf"
           target="_blank"
           rel="noopener noreferrer"
-          className="mt-4 inline-flex items-center typography-body-sm font-semibold text-[var(--brand-emerald)] underline decoration-[color-mix(in_srgb,var(--brand-emerald)_45%,#032823_55%)] decoration-2 underline-offset-4 transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]"
+          className="mt-4 inline-flex items-center typography-body-sm font-semibold text-[var(--brand-emerald)] underline decoration-[color-mix(in_srgb,var(--brand-emerald)_45%,var(--emerald-ink)_55%)] decoration-2 underline-offset-4 transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_80%,var(--emerald-ink)_20%)]"
         >
           Download the board briefing packet (PDF)
         </a>

--- a/src/components/QuickGateways.jsx
+++ b/src/components/QuickGateways.jsx
@@ -25,18 +25,18 @@ const gateways = [
 
 export default function QuickGateways() {
   return (
-    <section className="bg-white py-16" id="gateways">
+    <section className="bg-[var(--brand-white)] py-16" id="gateways">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="flex flex-col items-start justify-between gap-8 md:flex-row md:items-end">
           <div>
             <AccentPill size="sm" className="tracking-[0.25em]">
               Our Services
             </AccentPill>
-            <h2 className="mt-4 typography-heading-2 font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_88%,#032823_12%)]">
+            <h2 className="mt-4 typography-heading-2 font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_82%,var(--emerald-ink)_18%)]">
               Enterprise-ready solutions for every stakeholder
             </h2>
           </div>
-          <p className="max-w-xl typography-body-md text-[color-mix(in_srgb,var(--brand-emerald)_35%,#05382c_65%)]">
+          <p className="max-w-xl typography-body-md text-[color-mix(in_srgb,var(--brand-emerald)_35%,var(--emerald-canopy)_65%)]">
             Each of our services is designed with enterprise-grade security and reporting, ensuring that stakeholders at every level have the tools they need to succeed.
           </p>
         </div>
@@ -47,16 +47,16 @@ export default function QuickGateways() {
               <Link
                 key={title}
                 to={to}
-                className="group flex flex-col justify-between rounded-2xl border border-[color-mix(in_srgb,var(--brand-emerald)_25%,#ffffff)] bg-white p-6 shadow-lg shadow-black/5 transition hover:-translate-y-1 hover:border-[color-mix(in_srgb,var(--brand-emerald)_70%,#032823_30%)] hover:shadow-xl"
+                className="group flex flex-col justify-between rounded-2xl border border-[color-mix(in_srgb,var(--brand-emerald)_25%,var(--brand-white))] bg-[var(--brand-white)] p-6 shadow-lg shadow-black/5 transition hover:-translate-y-1 hover:border-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--emerald-ink)_30%)] hover:shadow-xl"
               >
-                <div className="flex size-12 items-center justify-center rounded-2xl bg-[color-mix(in_srgb,var(--brand-emerald)_12%,#ffffff_88%)] text-[var(--brand-emerald)] shadow-md shadow-black/5 transition group-hover:bg-[var(--brand-emerald)] group-hover:text-white">
+                <div className="flex size-12 items-center justify-center rounded-2xl bg-[color-mix(in_srgb,var(--brand-emerald)_12%,var(--brand-white)_88%)] text-[var(--brand-emerald)] shadow-md shadow-black/5 transition group-hover:bg-[var(--brand-emerald)] group-hover:text-[var(--brand-white)]">
                   <IconComponent className="size-6" aria-hidden="true" />
                 </div>
                 <div>
                   <h3 className="typography-heading-4 font-semibold text-[var(--brand-emerald)]">{title}</h3>
-                  <p className="mt-2 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_35%,#05382c_65%)]">{description}</p>
+                  <p className="mt-2 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_35%,var(--emerald-canopy)_65%)]">{description}</p>
                 </div>
-                <span className="inline-flex items-center justify-start typography-body-sm font-semibold text-[var(--brand-emerald)] transition group-hover:text-[color-mix(in_srgb,var(--brand-emerald)_70%,#032823_30%)]">
+                <span className="inline-flex items-center justify-start typography-body-sm font-semibold text-[var(--brand-emerald)] transition group-hover:text-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--emerald-ink)_30%)]">
                   Explore
                   <svg
                     className="ml-2 size-4 transition group-hover:translate-x-1"

--- a/src/components/TrustedBySchools.jsx
+++ b/src/components/TrustedBySchools.jsx
@@ -15,12 +15,12 @@ export default function TrustedBySchools() {
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <p className="inline-flex items-center gap-2 rounded-full border border-[var(--brand-emerald)]/20 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,#032823_15%)]">
+            <p className="inline-flex items-center gap-2 rounded-full border border-[var(--brand-emerald)]/20 bg-[var(--brand-white)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)]">
               Trusted by schools
             </p>
             <h2 className="mt-4 typography-heading-2 font-semibold text-[var(--brand-emerald)]">Serving Uganda’s most trusted institutions</h2>
           </div>
-          <p className="max-w-xl typography-body-sm text-slate-600">
+          <p className="max-w-xl typography-body-sm text-[color-mix(in_srgb,var(--emerald-bough)_85%,var(--emerald-mist)_15%)]">
             From rural diocesan schools to national academies, Skooli powers reliable delivery and transparent reporting.
           </p>
         </div>
@@ -28,10 +28,10 @@ export default function TrustedBySchools() {
           {schools.map((school) => (
             <div
               key={school.name}
-              className="group flex h-24 items-center justify-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 text-center typography-body-sm font-semibold tracking-wide text-slate-500 shadow-sm transition hover:-translate-y-0.5 hover:border-[var(--brand-emerald)] hover:shadow-md"
+              className="group flex h-24 items-center justify-center gap-2 rounded-2xl border border-[color-mix(in_srgb,var(--emerald-haze)_25%,var(--brand-white)_75%)] bg-[var(--brand-white)] px-4 text-center typography-body-sm font-semibold tracking-wide text-[color-mix(in_srgb,var(--emerald-bough)_70%,var(--emerald-mist)_30%)] shadow-sm transition hover:-translate-y-0.5 hover:border-[var(--brand-emerald)] hover:shadow-md"
               title={school.tooltip}
             >
-              <Shield className="size-4 text-slate-400 transition group-hover:text-[var(--brand-emerald)]" aria-hidden="true" />
+              <Shield className="size-4 text-[color-mix(in_srgb,var(--brand-emerald)_40%,var(--emerald-bough)_60%)] transition group-hover:text-[var(--brand-emerald)]" aria-hidden="true" />
               <span className="uppercase">{school.name}</span>
             </div>
           ))}

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -49,7 +49,7 @@ export default function Header() {
   }
 
   return (
-    <header className="sticky top-0 z-50 border-b border-slate-200 bg-white/95 backdrop-blur">
+    <header className="sticky top-0 z-50 border-b border-[color-mix(in_srgb,var(--emerald-haze)_25%,var(--brand-white)_75%)] bg-white/95 backdrop-blur">
       <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
         <Link to="/" className="flex items-center gap-2 text-[var(--brand-emerald)]">
           <span className="text-2xl font-bold tracking-tight">Skooli</span>
@@ -60,7 +60,7 @@ export default function Header() {
               key={to}
               to={to}
               className={({ isActive }) =>
-                `relative rounded-md border border-slate-200 bg-white px-4 py-2 text-sm font-semibold shadow-[0_6px_18px_rgba(13,37,29,0.08)] transition-all duration-200 after:absolute after:inset-x-3 after:bottom-1 after:h-1 after:rounded-full after:bg-transparent after:transition-colors after:content-[''] ${
+                `relative rounded-md border border-[color-mix(in_srgb,var(--emerald-haze)_25%,var(--brand-white)_75%)] bg-white px-4 py-2 text-sm font-semibold shadow-[0_6px_18px_rgba(13,37,29,0.08)] transition-all duration-200 after:absolute after:inset-x-3 after:bottom-1 after:h-1 after:rounded-full after:bg-transparent after:transition-colors after:content-[''] ${
                   isActive
                     ? 'text-[var(--brand-emerald)] ring-1 ring-[var(--brand-emerald)]/20 shadow-[0_10px_28px_rgba(5,56,44,0.12)] after:bg-[var(--brand-emerald)]'
                     : 'text-slate-700 hover:-translate-y-0.5 hover:text-[var(--brand-emerald)] hover:shadow-[0_12px_30px_rgba(5,56,44,0.16)] hover:after:bg-[var(--brand-emerald)]/70'
@@ -83,7 +83,7 @@ export default function Header() {
         <button
           type="button"
           onClick={() => setOpen((prev) => !prev)}
-          className="rounded-md border border-slate-200 p-2 text-[var(--brand-emerald)] shadow-sm transition hover:border-[color-mix(in_srgb,var(--brand-emerald)_70%,#032823_30%)] hover:text-[color-mix(in_srgb,var(--brand-emerald)_70%,#032823_30%)] lg:hidden"
+          className="rounded-md border border-[color-mix(in_srgb,var(--emerald-haze)_25%,var(--brand-white)_75%)] p-2 text-[var(--brand-emerald)] shadow-sm transition hover:border-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--emerald-ink)_30%)] hover:text-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--emerald-ink)_30%)] lg:hidden"
           aria-label="Toggle navigation"
           aria-expanded={open}
           aria-controls="mobile-navigation"
@@ -95,7 +95,7 @@ export default function Header() {
       </div>
       <div
         id="mobile-navigation"
-        className="border-t border-slate-200 bg-white/95 shadow-lg shadow-black/5 lg:hidden"
+        className="border-t border-[color-mix(in_srgb,var(--emerald-haze)_25%,var(--brand-white)_75%)] bg-white/95 shadow-lg shadow-black/5 lg:hidden"
         hidden={!open}
       >
         <nav aria-label="Mobile" className="mx-auto flex max-w-7xl flex-col gap-1 px-4 py-4">
@@ -123,7 +123,7 @@ export default function Header() {
           <div className="mt-4 flex flex-col gap-2">
             <Button
               variant="ghost"
-              className="w-full rounded-md py-2 text-sm font-semibold text-[var(--brand-emerald)] hover:text-[color-mix(in_srgb,var(--brand-emerald)_80%,#032823_20%)]"
+              className="w-full rounded-md py-2 text-sm font-semibold text-[var(--brand-emerald)] hover:text-[color-mix(in_srgb,var(--brand-emerald)_80%,var(--emerald-ink)_20%)]"
               asChild
             >
               <Link to="/funders#investor-deck" onClick={closeMenu}>

--- a/src/components/ui/chart.jsx
+++ b/src/components/ui/chart.jsx
@@ -37,7 +37,7 @@ function ChartContainer({
         data-slot="chart"
         data-chart={chartId}
         className={cn(
-          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='var(--neutral-cloud)']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='var(--neutral-cloud)']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='var(--neutral-cloud)']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='var(--brand-white)']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='var(--brand-white)']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
           className
         )}
         {...props}>

--- a/src/index.css
+++ b/src/index.css
@@ -61,13 +61,6 @@
 }
 
 :root {
-  --brand-emerald: #009B77;
-  --brand-emerald-dark: #032823;
-  --brand-emerald-light: #7fd1b9;
-  --brand-cream: #FDF4D5;
-  --brand-gold: #FFD700;
-  --brand-white: #FFFFFF;
-
   --radius: 1rem; /* 16px for cards, 8px for buttons */
   --background: var(--brand-cream); /* Warm Skooli cream */
   --foreground: var(--brand-emerald); /* Emerald for headings and key text */
@@ -80,18 +73,18 @@
   --secondary: var(--brand-cream);
   --secondary-foreground: var(--brand-emerald);
   --muted: color-mix(in srgb, var(--brand-cream) 70%, var(--brand-white));
-  --muted-foreground: #26594c;
+  --muted-foreground: var(--emerald-bough);
   --accent: var(--brand-gold);
-  --accent-foreground: var(--brand-emerald-dark);
+  --accent-foreground: var(--emerald-ink);
   --destructive: #c2410c;
   --border: color-mix(in srgb, var(--brand-emerald) 15%, var(--brand-white));
   --input: color-mix(in srgb, var(--brand-cream) 80%, var(--brand-white));
-  --ring: color-mix(in srgb, var(--brand-emerald) 65%, #05382c);
+  --ring: color-mix(in srgb, var(--brand-emerald) 65%, var(--emerald-canopy));
   --chart-1: var(--brand-emerald);
   --chart-2: color-mix(in srgb, var(--brand-emerald) 65%, var(--brand-emerald-light) 35%);
   --chart-3: var(--brand-emerald-light);
   --chart-4: color-mix(in srgb, var(--brand-emerald) 50%, var(--brand-emerald-light) 50%);
-  --chart-5: color-mix(in srgb, var(--brand-emerald-dark) 65%, var(--brand-emerald-light) 35%);
+  --chart-5: color-mix(in srgb, var(--emerald-ink) 65%, var(--brand-emerald-light) 35%);
   --sidebar: var(--brand-white);
   --sidebar-foreground: var(--brand-emerald);
   --sidebar-primary: var(--brand-emerald);
@@ -99,41 +92,41 @@
   --sidebar-accent: color-mix(in srgb, var(--brand-emerald) 80%, var(--brand-emerald-light) 20%);
   --sidebar-accent-foreground: var(--brand-white);
   --sidebar-border: color-mix(in srgb, var(--brand-emerald) 20%, var(--brand-white));
-  --sidebar-ring: color-mix(in srgb, var(--brand-emerald) 65%, #05382c);
+  --sidebar-ring: color-mix(in srgb, var(--brand-emerald) 65%, var(--emerald-canopy));
 }
 
 .dark {
   --background: #021d18;
   --foreground: #e3fff9;
-  --card: #032823;
+  --card: var(--emerald-ink);
   --card-foreground: #e3fff9;
-  --popover: #032823;
+  --popover: var(--emerald-ink);
   --popover-foreground: #e3fff9;
   --primary: color-mix(in srgb, var(--brand-emerald) 70%, var(--brand-emerald-light) 30%);
   --primary-foreground: #021d18;
-  --secondary: #094236;
+  --secondary: color-mix(in srgb, var(--emerald-canopy) 85%, transparent);
   --secondary-foreground: #e3fff9;
-  --muted: #094236;
+  --muted: color-mix(in srgb, var(--emerald-canopy) 85%, transparent);
   --muted-foreground: var(--brand-emerald-light);
   --accent: var(--brand-gold);
   --accent-foreground: #021d18;
   --destructive: #f97316;
   --border: color-mix(in srgb, var(--brand-emerald) 25%, transparent);
   --input: color-mix(in srgb, var(--brand-emerald) 35%, transparent);
-  --ring: rgba(0, 152, 119, 0.6);
+  --ring: color-mix(in srgb, var(--brand-emerald) 60%, var(--brand-emerald-light) 40%);
   --chart-1: var(--brand-emerald-light);
   --chart-2: color-mix(in srgb, var(--brand-emerald) 55%, var(--brand-emerald-light) 45%);
   --chart-3: #a5edd5;
   --chart-4: #5ad1b0;
   --chart-5: #b6f7e5;
-  --sidebar: #032823;
+  --sidebar: var(--emerald-ink);
   --sidebar-foreground: #e3fff9;
   --sidebar-primary: color-mix(in srgb, var(--brand-emerald) 68%, var(--brand-emerald-light) 32%);
   --sidebar-primary-foreground: #021d18;
   --sidebar-accent: color-mix(in srgb, var(--brand-emerald) 55%, var(--brand-emerald-light) 45%);
   --sidebar-accent-foreground: #021d18;
   --sidebar-border: color-mix(in srgb, var(--brand-emerald) 20%, transparent);
-  --sidebar-ring: rgba(0, 152, 119, 0.6);
+  --sidebar-ring: color-mix(in srgb, var(--brand-emerald) 60%, var(--brand-emerald-light) 40%);
 }
 
 /* Skooli Custom Styles */

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,4 +1,5 @@
 :root {
+  /* Typography */
   --font-family-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 
   --font-size-display: clamp(2.75rem, 1.25rem + 4vw, 4rem);
@@ -15,6 +16,22 @@
   --line-height-snug: 1.25;
   --line-height-relaxed: 1.4;
   --line-height-body: 1.6;
+
+  /* Core palette */
+  --brand-emerald: #009877;
+  --brand-gold: #ffd700;
+  --brand-cream: #fce6ae;
+  --brand-emerald-light: #7fd1b9;
+  --brand-white: #ffffff;
+  --neutral-black: #000000;
+
+  /* Emerald depth + neutrals */
+  --emerald-ink: #032823;
+  --emerald-canopy: #05382c;
+  --emerald-bough: #4c625b;
+  --emerald-mist: #8b9f99;
+  --emerald-haze: #8da49a;
+  --neutral-cloud: #cccccc;
 }
 
 body {


### PR DESCRIPTION
## Summary
- add the Skooli palette to `tokens.css` and reuse those variables for global theme values
- replace literal color values across components with palette-driven CSS variables and color-mix utilities
- darken secondary text pairings to meet contrast requirements while keeping brand styling consistent

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_6902c8c4c980832b8afc9242b0c38cbc