### PR TITLE
Align homepage spacing with new layout tokens

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -32,7 +32,7 @@ const footerSections = {
 
 export default function Footer() {
   return (
-    <footer className="relative overflow-hidden text-[color-mix(in_srgb,var(--brand-emerald)_88%,var(--emerald-ink)_12%)]">
+    <footer className="section-shell relative overflow-hidden text-[color-mix(in_srgb,var(--brand-emerald)_88%,var(--emerald-ink)_12%)]">
       <div
         className="absolute inset-0"
         style={{
@@ -45,18 +45,18 @@ export default function Footer() {
         className="absolute inset-0 opacity-70 mix-blend-luminosity"
         style={{ backgroundImage: `url(${leadershipGradient})`, backgroundSize: 'cover', backgroundPosition: 'center' }}
       />
-      <div className="relative mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-        <div className="grid grid-cols-1 gap-12 md:grid-cols-2 lg:grid-cols-4">
-          <div className="space-y-6">
+      <div className="relative section-container">
+        <div className="grid grid-cols-1 gap-[var(--space-2xl)] md:grid-cols-2 lg:grid-cols-4">
+          <div className="space-y-[var(--space-lg)]">
             <div>
               <h2 className="typography-heading-3 font-bold text-[var(--brand-emerald)]">Skooli</h2>
-              <p className="mt-4 max-w-xs typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,var(--emerald-ink)_22%)]">
+              <p className="mt-[var(--space-sm)] max-w-xs typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,var(--emerald-ink)_22%)]">
                 Education logistics built for every Ugandan learner. Ethically sourced.
                 Efficiently delivered. Faithfully stewarded.
               </p>
             </div>
-            <div className="space-y-4 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,var(--emerald-ink)_22%)]">
-              <div className="flex items-start gap-3">
+            <div className="space-y-[var(--space-sm)] typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,var(--emerald-ink)_22%)]">
+              <div className="flex items-start gap-[var(--space-sm)]">
                 <MapPin className="mt-0.5 size-5 text-[var(--brand-emerald)]" />
                 <div>
                   <p className="typography-body-sm font-semibold text-[var(--brand-emerald)]">Uganda HQ</p>
@@ -64,7 +64,7 @@ export default function Footer() {
                   <p>Kampala, Uganda</p>
                 </div>
               </div>
-              <div className="flex items-start gap-3">
+              <div className="flex items-start gap-[var(--space-sm)]">
                 <MapPin className="mt-0.5 size-5 text-[var(--brand-emerald)]" />
                 <div>
                   <p className="typography-body-sm font-semibold text-[var(--brand-emerald)]">UK Office</p>
@@ -72,20 +72,20 @@ export default function Footer() {
                   <p>London, EC1V 2NX</p>
                 </div>
               </div>
-              <div className="flex items-center gap-3">
+              <div className="flex items-center gap-[var(--space-sm)]">
                 <Mail className="size-5 text-[var(--brand-emerald)]" />
                 <a className="typography-body-sm font-semibold text-[var(--brand-emerald)] transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)]" href="mailto:hello@skooli.africa">
                   hello@skooli.africa
                 </a>
               </div>
-              <div className="flex items-center gap-3">
+              <div className="flex items-center gap-[var(--space-sm)]">
                 <Phone className="size-5 text-[var(--brand-emerald)]" />
                 <a className="typography-body-sm font-semibold text-[var(--brand-emerald)] transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)]" href="tel:+256414000000">
                   +256 414 000 000
                 </a>
               </div>
             </div>
-            <div className="flex gap-3">
+            <div className="flex gap-[var(--space-sm)]">
               <a
                 className="flex size-10 items-center justify-center rounded-full border border-[var(--brand-emerald)]/20 bg-[var(--brand-white)] text-[var(--brand-emerald)] shadow-sm transition hover:-translate-y-0.5 hover:bg-[var(--brand-emerald)] hover:text-[var(--brand-white)]"
                 href="https://www.linkedin.com/company/skooli"
@@ -118,7 +118,7 @@ export default function Footer() {
 
           <div>
             <h3 className="typography-heading-4 font-semibold text-[var(--brand-emerald)]">Company</h3>
-            <ul className="mt-6 space-y-3 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,var(--emerald-ink)_22%)]">
+            <ul className="mt-[var(--space-md)] space-y-[var(--space-2xs)] typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,var(--emerald-ink)_22%)]">
               {footerSections.company.map((item) => (
                 <li key={item.label}>
                   <Link className="transition hover:text-[var(--brand-emerald)]" to={item.to}>
@@ -131,7 +131,7 @@ export default function Footer() {
 
           <div>
             <h3 className="typography-heading-4 font-semibold text-[var(--brand-emerald)]">Services</h3>
-            <ul className="mt-6 space-y-3 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,var(--emerald-ink)_22%)]">
+            <ul className="mt-[var(--space-md)] space-y-[var(--space-2xs)] typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,var(--emerald-ink)_22%)]">
               {footerSections.services.map((item) => (
                 <li key={item.label}>
                   <Link className="transition hover:text-[var(--brand-emerald)]" to={item.to}>
@@ -144,7 +144,7 @@ export default function Footer() {
 
           <div>
             <h3 className="typography-heading-4 font-semibold text-[var(--brand-emerald)]">Resources & Legal</h3>
-            <ul className="mt-6 space-y-3 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,var(--emerald-ink)_22%)]">
+            <ul className="mt-[var(--space-md)] space-y-[var(--space-2xs)] typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_78%,var(--emerald-ink)_22%)]">
               {[...footerSections.resources, ...footerSections.legal].map((item) => (
                 <li key={item.label}>
                   <Link className="transition hover:text-[var(--brand-emerald)]" to={item.to}>
@@ -153,11 +153,11 @@ export default function Footer() {
                 </li>
               ))}
             </ul>
-            <div className="mt-8 space-y-3 rounded-2xl border border-[var(--brand-emerald)]/15 bg-[color-mix(in_srgb,var(--brand-cream)_75%,var(--brand-white)_25%)] p-4 shadow-sm">
+            <div className="mt-[var(--space-xl)] space-y-[var(--space-2xs)] rounded-2xl border border-[var(--brand-emerald)]/15 bg-[color-mix(in_srgb,var(--brand-cream)_75%,var(--brand-white)_25%)] p-[var(--space-md)] shadow-sm">
               <p className="typography-body-sm font-semibold text-[var(--brand-emerald)]">Stay in the loop</p>
               <p className="typography-body-xs text-[color-mix(in_srgb,var(--brand-emerald)_60%,var(--emerald-ink)_40%)]">Monthly executive briefings on logistics, impact and technology.</p>
               <form
-                className="flex items-center gap-2"
+                className="flex items-center gap-[var(--space-2xs)]"
                 onSubmit={(event) => {
                   event.preventDefault()
                   const form = event.currentTarget
@@ -169,7 +169,7 @@ export default function Footer() {
                 }}
               >
                 <input
-                  className="h-10 flex-1 rounded-full border border-[var(--brand-emerald)]/25 bg-[var(--brand-white)] px-3 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_80%,var(--emerald-ink)_20%)] placeholder:text-[color-mix(in_srgb,var(--brand-emerald)_45%,var(--emerald-haze)_55%)] focus:border-[var(--brand-emerald)] focus:outline-none"
+                  className="h-10 flex-1 rounded-full border border-[var(--brand-emerald)]/25 bg-[var(--brand-white)] px-[var(--space-xs)] typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_80%,var(--emerald-ink)_20%)] placeholder:text-[color-mix(in_srgb,var(--brand-emerald)_45%,var(--emerald-haze)_55%)] focus:border-[var(--brand-emerald)] focus:outline-none"
                   type="email"
                   name="email"
                   aria-label="Email for newsletter"
@@ -178,7 +178,7 @@ export default function Footer() {
                 />
                 <button
                   type="submit"
-                  className="flex h-10 items-center justify-center rounded-full bg-[var(--brand-emerald)] px-4 typography-body-sm font-semibold text-[var(--brand-white)] shadow-sm shadow-black/10 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)]"
+                  className="flex h-10 items-center justify-center rounded-full bg-[var(--brand-emerald)] px-[var(--space-sm)] typography-body-sm font-semibold text-[var(--brand-white)] shadow-sm shadow-black/10 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)]"
                 >
                   <Send className="size-4" />
                 </button>
@@ -186,10 +186,10 @@ export default function Footer() {
             </div>
           </div>
         </div>
-        <div className="mt-12 border-t border-[var(--brand-emerald)]/20 pt-6">
-          <div className="flex flex-col gap-4 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_72%,var(--emerald-ink)_28%)] md:flex-row md:items-center md:justify-between">
+        <div className="mt-[var(--space-3xl)] border-t border-[var(--brand-emerald)]/20 pt-[var(--space-md)]">
+          <div className="flex flex-col gap-[var(--space-md)] typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_72%,var(--emerald-ink)_28%)] md:flex-row md:items-center md:justify-between">
             <p>© {new Date().getFullYear()} Skooli Technologies Group Ltd. All rights reserved.</p>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-[var(--space-2xs)]">
               <span>Made with</span>
               <Heart className="size-4 text-[var(--brand-emerald)]" />
               <span>for African education</span>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -29,7 +29,7 @@ const handleHeroImageError = (event) => {
 
 export default function Hero() {
   return (
-    <section className="relative flex min-h-[85vh] items-center justify-start overflow-hidden" id="hero">
+    <section className="section-shell relative flex min-h-[85vh] items-center justify-start overflow-hidden" id="hero">
       <div className="absolute inset-0">
         <picture>
           <source type="image/jpeg" srcSet="/assets/branding/skooli_banner_image.jpg" sizes="100vw" />
@@ -49,21 +49,21 @@ export default function Hero() {
           aria-hidden="true"
         />
       </div>
-      <div className="relative z-10 mx-auto max-w-7xl px-4 py-24 text-left text-[var(--brand-white)] sm:px-6 lg:px-8">
+      <div className="relative z-10 section-container text-left text-[var(--brand-white)]">
         <div className="max-w-2xl">
           <AccentPill tone="inverse" size="sm" className="bg-[color-mix(in_srgb,var(--brand-white)_20%,transparent)]">
             Executive briefing
           </AccentPill>
-          <h1 className="mt-6 typography-display font-semibold text-[var(--brand-white)]">
+          <h1 className="mt-[var(--space-md)] typography-display font-semibold text-[var(--brand-white)]">
             Operational assurance for national education pilots
           </h1>
-          <p className="mt-6 typography-body-lg font-medium text-[color-mix(in_srgb,var(--brand-white)_90%,transparent)]">
+          <p className="mt-[var(--space-md)] typography-body-lg font-medium text-[color-mix(in_srgb,var(--brand-white)_90%,transparent)]">
             Skooli deploys accountable facilitators, verified suppliers, and transparent financial rails so ministries see auditable results from the first cohort through national scale.
           </p>
-          <div className="mt-10">
+          <div className="mt-[var(--space-xl)]">
             <Button
               size="lg"
-              className="rounded-md bg-[var(--brand-emerald)] px-8 py-4 text-base font-semibold text-[var(--brand-white)] shadow-lg shadow-black/10 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_80%,var(--emerald-ink)_20%)]"
+              className="rounded-md bg-[var(--brand-emerald)] px-[var(--space-xl)] py-[var(--space-sm)] text-base font-semibold text-[var(--brand-white)] shadow-lg shadow-black/10 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_80%,var(--emerald-ink)_20%)]"
               asChild
             >
               <Link to="/downloads/skooli-impact-report-2025.pdf" target="_blank" rel="noreferrer noopener">

--- a/src/components/HeroStats.jsx
+++ b/src/components/HeroStats.jsx
@@ -5,14 +5,14 @@ export default function HeroStats() {
     { value: '4.8/5', label: 'Facilitator satisfaction from pilot surveys' },
   ]
   return (
-    <section className="-mt-10 bg-transparent pb-6">
-      <div className="mx-auto max-w-6xl px-4">
-        <div className="grid gap-4 rounded-2xl bg-[color-mix(in_srgb,var(--brand-white)_95%,transparent)] p-4 shadow-xl shadow-black/5 backdrop-blur sm:grid-cols-3">
+    <section className="section-shell bg-transparent" data-spacing="tight">
+      <div className="section-container max-w-6xl">
+        <div className="grid gap-[var(--space-md)] rounded-2xl bg-[color-mix(in_srgb,var(--brand-white)_95%,transparent)] p-[var(--space-md)] shadow-xl shadow-black/5 backdrop-blur sm:grid-cols-3">
           {items.map((item) => (
-            <div key={item.label} className="flex items-center justify-center rounded-xl p-4 text-center">
+            <div key={item.label} className="flex items-center justify-center rounded-xl p-[var(--space-md)] text-center">
               <div>
                 <p className="typography-heading-3 font-bold text-[var(--brand-emerald)]">{item.value}</p>
-                <p className="mt-1 typography-body-sm font-medium text-[color-mix(in_srgb,var(--brand-emerald)_25%,var(--emerald-canopy)_75%)]">
+                <p className="mt-[var(--space-3xs)] typography-body-sm font-medium text-[color-mix(in_srgb,var(--brand-emerald)_25%,var(--emerald-canopy)_75%)]">
                   {item.label}
                 </p>
               </div>

--- a/src/components/NewsletterSignupModule.jsx
+++ b/src/components/NewsletterSignupModule.jsx
@@ -20,8 +20,8 @@ export function NewsletterSignupModule({ layout = 'horizontal', includeDownloadL
 
   const isHorizontal = layout === 'horizontal'
   const formClasses = isHorizontal
-    ? 'flex w-full max-w-md flex-col gap-3 sm:flex-row'
-    : 'flex w-full flex-col gap-3'
+    ? 'flex w-full max-w-md flex-col gap-[var(--space-xs)] sm:flex-row'
+    : 'flex w-full flex-col gap-[var(--space-xs)]'
 
   return (
     <div className={className}>
@@ -32,18 +32,18 @@ export function NewsletterSignupModule({ layout = 'horizontal', includeDownloadL
           value={email}
           onChange={(event) => setEmail(event.target.value)}
           placeholder="you@organisation.com"
-          className={`h-12 flex-1 rounded-full border border-[color-mix(in_srgb,var(--brand-emerald)_25%,var(--brand-white))] bg-[var(--brand-white)] px-4 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_75%,var(--emerald-canopy)_25%)] placeholder:text-[color-mix(in_srgb,var(--brand-emerald)_40%,var(--emerald-bough)_60%)] focus:border-[var(--brand-emerald)] focus:outline-none ${
+          className={`h-12 flex-1 rounded-full border border-[color-mix(in_srgb,var(--brand-emerald)_25%,var(--brand-white))] bg-[var(--brand-white)] px-[var(--space-sm)] typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_75%,var(--emerald-canopy)_25%)] placeholder:text-[color-mix(in_srgb,var(--brand-emerald)_40%,var(--emerald-bough)_60%)] focus:border-[var(--brand-emerald)] focus:outline-none ${
             isHorizontal ? '' : 'w-full'
           }`}
           aria-label="Email address"
         />
         <button
           type="submit"
-          className="flex h-12 items-center justify-center rounded-full bg-[var(--brand-emerald)] px-6 typography-body-sm font-semibold text-[var(--brand-white)] shadow-lg shadow-black/15 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)] whitespace-nowrap"
+          className="flex h-12 items-center justify-center rounded-full bg-[var(--brand-emerald)] px-[var(--space-md)] typography-body-sm font-semibold text-[var(--brand-white)] shadow-lg shadow-black/15 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)] whitespace-nowrap"
           disabled={status === 'loading'}
         >
           {status === 'loading' ? 'Delivering…' : status === 'success' ? 'Briefing Sent!' : 'Send briefing PDF'}
-          <Send className="ml-2 size-4" aria-hidden="true" />
+          <Send className="ml-[var(--space-2xs)] size-4" aria-hidden="true" />
         </button>
       </form>
       {includeDownloadLink ? (
@@ -51,7 +51,7 @@ export function NewsletterSignupModule({ layout = 'horizontal', includeDownloadL
           href="/downloads/skooli-pitch-deck-q3-2025.pdf"
           target="_blank"
           rel="noopener noreferrer"
-          className="mt-4 inline-flex items-center typography-body-sm font-semibold text-[var(--brand-emerald)] underline decoration-[color-mix(in_srgb,var(--brand-emerald)_45%,var(--emerald-ink)_55%)] decoration-2 underline-offset-4 transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_80%,var(--emerald-ink)_20%)]"
+          className="mt-[var(--space-sm)] inline-flex items-center typography-body-sm font-semibold text-[var(--brand-emerald)] underline decoration-[color-mix(in_srgb,var(--brand-emerald)_45%,var(--emerald-ink)_55%)] decoration-2 underline-offset-4 transition hover:text-[color-mix(in_srgb,var(--brand-emerald)_80%,var(--emerald-ink)_20%)]"
         >
           Download the board briefing packet (PDF)
         </a>

--- a/src/components/QuickGateways.jsx
+++ b/src/components/QuickGateways.jsx
@@ -25,14 +25,14 @@ const gateways = [
 
 export default function QuickGateways() {
   return (
-    <section className="bg-[var(--brand-white)] py-16" id="gateways">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="flex flex-col items-start justify-between gap-8 md:flex-row md:items-end">
+    <section className="section-shell bg-[var(--brand-white)]" id="gateways">
+      <div className="section-container">
+        <div className="flex flex-col items-start justify-between gap-[var(--space-xl)] md:flex-row md:items-end">
           <div>
             <AccentPill size="sm" className="tracking-[0.25em]">
               Our Services
             </AccentPill>
-            <h2 className="mt-4 typography-heading-2 font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_82%,var(--emerald-ink)_18%)]">
+            <h2 className="mt-[var(--space-sm)] typography-heading-2 font-semibold text-[color-mix(in_srgb,var(--brand-emerald)_82%,var(--emerald-ink)_18%)]">
               Enterprise-ready solutions for every stakeholder
             </h2>
           </div>
@@ -40,26 +40,26 @@ export default function QuickGateways() {
             Each of our services is designed with enterprise-grade security and reporting, ensuring that stakeholders at every level have the tools they need to succeed.
           </p>
         </div>
-        <div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="mt-[var(--space-2xl)] grid gap-[var(--space-lg)] sm:grid-cols-2 lg:grid-cols-3">
           {gateways.map(({ title, description, icon, to }) => {
             const IconComponent = icon
             return (
               <Link
                 key={title}
                 to={to}
-                className="group flex flex-col justify-between rounded-2xl border border-[color-mix(in_srgb,var(--brand-emerald)_25%,var(--brand-white))] bg-[var(--brand-white)] p-6 shadow-lg shadow-black/5 transition hover:-translate-y-1 hover:border-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--emerald-ink)_30%)] hover:shadow-xl"
+                className="group flex flex-col justify-between rounded-2xl border border-[color-mix(in_srgb,var(--brand-emerald)_25%,var(--brand-white))] bg-[var(--brand-white)] p-[var(--space-lg)] shadow-lg shadow-black/5 transition hover:-translate-y-1 hover:border-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--emerald-ink)_30%)] hover:shadow-xl"
               >
                 <div className="flex size-12 items-center justify-center rounded-2xl bg-[color-mix(in_srgb,var(--brand-emerald)_12%,var(--brand-white)_88%)] text-[var(--brand-emerald)] shadow-md shadow-black/5 transition group-hover:bg-[var(--brand-emerald)] group-hover:text-[var(--brand-white)]">
                   <IconComponent className="size-6" aria-hidden="true" />
                 </div>
                 <div>
                   <h3 className="typography-heading-4 font-semibold text-[var(--brand-emerald)]">{title}</h3>
-                  <p className="mt-2 typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_35%,var(--emerald-canopy)_65%)]">{description}</p>
+                  <p className="mt-[var(--space-2xs)] typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_35%,var(--emerald-canopy)_65%)]">{description}</p>
                 </div>
                 <span className="inline-flex items-center justify-start typography-body-sm font-semibold text-[var(--brand-emerald)] transition group-hover:text-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--emerald-ink)_30%)]">
                   Explore
                   <svg
-                    className="ml-2 size-4 transition group-hover:translate-x-1"
+                    className="ml-[var(--space-2xs)] size-4 transition group-hover:translate-x-1"
                     xmlns="http://www.w3.org/2000/svg"
                     viewBox="0 0 24 24"
                     fill="none"

--- a/src/index.css
+++ b/src/index.css
@@ -93,6 +93,7 @@
   --sidebar-accent-foreground: var(--brand-white);
   --sidebar-border: color-mix(in srgb, var(--brand-emerald) 20%, var(--brand-white));
   --sidebar-ring: color-mix(in srgb, var(--brand-emerald) 65%, var(--emerald-canopy));
+  --section-max-width: 80rem;
 }
 
 .dark {
@@ -134,6 +135,20 @@ body {
   font-family: 'Inter', system-ui, sans-serif;
 }
 
+.section-shell {
+  padding-block: var(--space-section-y);
+}
+
+.section-shell[data-spacing='tight'] {
+  padding-block: var(--space-section-tight-y);
+}
+
+.section-container {
+  margin-inline: auto;
+  width: min(100%, var(--section-max-width));
+  padding-inline: var(--space-section-inline);
+}
+
 /* Tone of voice guide ------------------------------------------------------
    Skooli copy should sound hopeful, dignifying, and pragmatic. Lead with
    evidence-backed impact, avoid hype, and always center the families and
@@ -165,7 +180,8 @@ body {
 
 /* Card styles */
 .skooli-card {
-  @apply bg-white rounded-3xl shadow-lg shadow-black/5 p-6;
+  @apply bg-white rounded-3xl shadow-lg shadow-black/5;
+  padding: var(--space-lg);
 }
 
 /* Hero overlay */

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -32,6 +32,24 @@
   --emerald-mist: #8b9f99;
   --emerald-haze: #8da49a;
   --neutral-cloud: #cccccc;
+
+  /* Spacing scale */
+  --space-3xs: 0.25rem;
+  --space-2xs: 0.5rem;
+  --space-xs: 0.75rem;
+  --space-sm: 1rem;
+  --space-md: 1.5rem;
+  --space-lg: 2rem;
+  --space-xl: 2.5rem;
+  --space-2xl: 3rem;
+  --space-3xl: 4rem;
+  --space-4xl: 5rem;
+  --space-5xl: 6rem;
+
+  /* Section layout */
+  --space-section-inline: clamp(var(--space-sm), 4vw, var(--space-xl));
+  --space-section-y: clamp(var(--space-3xl), 6vw, var(--space-5xl));
+  --space-section-tight-y: calc(var(--space-section-y) * 0.6);
 }
 
 body {


### PR DESCRIPTION
## Summary
- add spacing scale tokens and section layout variables for consistent gutters
- refactor hero, hero stats, features, and footer sections to use the new spacing tokens
- update cards and newsletter forms to remove negative offsets and align padding with the spacing scale

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_6902ccb9bfec832b8d8474830e09164b