### PR TITLE
feat: implement reusable ui primitives

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,5 +1,8 @@
 import { Link } from 'react-router-dom'
 import { Mail, Phone, MapPin, Linkedin, Twitter, Youtube, Heart, Send } from 'lucide-react'
+import { Button } from '@/components/ui/button.jsx'
+import { Input } from '@/components/ui/input.jsx'
+import { Card } from '@/components/ui/card.jsx'
 import leadershipGradient from '@/assets/leadership-gradient.svg'
 import leadershipPortrait from '@/assets/leadership-portrait.svg'
 
@@ -153,11 +156,15 @@ export default function Footer() {
                 </li>
               ))}
             </ul>
-            <div className="mt-[var(--space-xl)] space-y-[var(--space-2xs)] rounded-2xl border border-[var(--brand-emerald)]/15 bg-[color-mix(in_srgb,var(--brand-cream)_75%,var(--brand-white)_25%)] p-[var(--space-md)] shadow-sm">
+            <Card
+              variant="muted"
+              padding="md"
+              className="mt-[var(--space-xl)] gap-[var(--space-2xs)] shadow-sm"
+            >
               <p className="typography-body-sm font-semibold text-[var(--brand-emerald)]">Stay in the loop</p>
               <p className="typography-body-xs text-[color-mix(in_srgb,var(--brand-emerald)_60%,var(--emerald-ink)_40%)]">Monthly executive briefings on logistics, impact and technology.</p>
               <form
-                className="flex items-center gap-[var(--space-2xs)]"
+                className="flex flex-col gap-[var(--space-2xs)] sm:flex-row sm:items-center"
                 onSubmit={(event) => {
                   event.preventDefault()
                   const form = event.currentTarget
@@ -168,22 +175,25 @@ export default function Footer() {
                   }
                 }}
               >
-                <input
-                  className="h-10 flex-1 rounded-full border border-[var(--brand-emerald)]/25 bg-[var(--brand-white)] px-[var(--space-xs)] typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_80%,var(--emerald-ink)_20%)] placeholder:text-[color-mix(in_srgb,var(--brand-emerald)_45%,var(--emerald-haze)_55%)] focus:border-[var(--brand-emerald)] focus:outline-none"
+                <Input
+                  className="flex-1 rounded-full bg-[var(--brand-white)]"
                   type="email"
                   name="email"
                   aria-label="Email for newsletter"
                   placeholder="you@organisation.com"
                   required
                 />
-                <button
+                <Button
                   type="submit"
-                  className="flex h-10 items-center justify-center rounded-full bg-[var(--brand-emerald)] px-[var(--space-sm)] typography-body-sm font-semibold text-[var(--brand-white)] shadow-sm shadow-black/10 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)]"
+                  variant="primary"
+                  shape="pill"
+                  className="w-full sm:w-auto"
                 >
-                  <Send className="size-4" />
-                </button>
+                  Subscribe
+                  <Send aria-hidden="true" className="size-4" />
+                </Button>
               </form>
-            </div>
+            </Card>
           </div>
         </div>
         <div className="mt-[var(--space-3xl)] border-t border-[var(--brand-emerald)]/20 pt-[var(--space-md)]">

--- a/src/components/NewsletterCTA.jsx
+++ b/src/components/NewsletterCTA.jsx
@@ -1,4 +1,5 @@
 import { NewsletterSignupModule } from '@/components/NewsletterSignupModule.jsx'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card.jsx'
 import { impactInsights } from '@/data/impactInsights.js'
 
 export default function NewsletterCTA() {
@@ -25,28 +26,47 @@ export default function NewsletterCTA() {
               <NewsletterSignupModule layout="horizontal" includeDownloadLink className="flex flex-col items-start gap-4" />
             </div>
 
-            <div className="rounded-3xl border border-[var(--brand-emerald)]/15 bg-white/70 p-6">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <Card
+              variant="surface"
+              padding="lg"
+              className="rounded-3xl border border-[var(--brand-emerald)]/15 bg-white/70 backdrop-blur-sm"
+            >
+              <CardHeader className="gap-3 p-0 sm:flex-row sm:items-center sm:justify-between">
                 <div>
-                  <p className="inline-flex items-center gap-2 rounded-full border border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_70%,var(--brand-white)_30%)] px-3 py-1 typography-body-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)]">
+                  <span className="inline-flex items-center gap-2 rounded-full border border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_70%,var(--brand-white)_30%)] px-3 py-1 typography-body-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)]">
                     Impact Insights
-                  </p>
-                  <h3 className="mt-2 typography-heading-4 font-semibold text-[var(--brand-emerald)]">Operational highlights from the latest quarter</h3>
+                  </span>
+                  <CardTitle className="mt-2 typography-heading-4 text-[var(--brand-emerald)]">
+                    Operational highlights from the latest quarter
+                  </CardTitle>
                 </div>
                 <span className="rounded-full border border-[var(--brand-emerald)]/15 bg-[color-mix(in_srgb,var(--brand-emerald)_8%,var(--brand-white)_92%)] px-4 py-1 typography-body-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)]">
                   Q3 2025
                 </span>
-              </div>
-              <div className="mt-6 grid gap-4 sm:grid-cols-3">
-                {impactInsights.map((item) => (
-                  <div key={item.label} className="rounded-2xl border border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_65%,var(--brand-white)_35%)] p-4">
-                    <p className="typography-body-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)]">{item.label}</p>
-                    <p className="mt-3 typography-heading-3 font-bold text-[var(--brand-emerald)]">{item.metric}</p>
-                    <p className="mt-2 typography-body-xs text-slate-600">{item.detail}</p>
-                  </div>
-                ))}
-              </div>
-            </div>
+              </CardHeader>
+              <CardContent className="gap-6 p-0">
+                <div className="grid gap-4 sm:grid-cols-3">
+                  {impactInsights.map((item) => (
+                    <Card
+                      key={item.label}
+                      variant="muted"
+                      padding="sm"
+                      className="gap-[var(--space-xs)] border-[var(--brand-emerald)]/20 bg-[color-mix(in_srgb,var(--brand-cream)_65%,var(--brand-white)_35%)]"
+                    >
+                      <span className="typography-body-xs font-semibold uppercase tracking-[0.3em] text-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)]">
+                        {item.label}
+                      </span>
+                      <CardTitle className="typography-heading-3 font-bold text-[var(--brand-emerald)]">
+                        {item.metric}
+                      </CardTitle>
+                      <CardDescription className="typography-body-xs text-slate-600">
+                        {item.detail}
+                      </CardDescription>
+                    </Card>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
           </div>
         </div>
       </div>

--- a/src/components/NewsletterSignupModule.jsx
+++ b/src/components/NewsletterSignupModule.jsx
@@ -1,5 +1,7 @@
 import { useState } from 'react'
 import { Send } from 'lucide-react'
+import { Button } from '@/components/ui/button.jsx'
+import { Input } from '@/components/ui/input.jsx'
 
 export function NewsletterSignupModule({ layout = 'horizontal', includeDownloadLink = false, className = '' }) {
   const [email, setEmail] = useState('')
@@ -26,25 +28,30 @@ export function NewsletterSignupModule({ layout = 'horizontal', includeDownloadL
   return (
     <div className={className}>
       <form onSubmit={handleSubmit} className={formClasses}>
-        <input
+        <Input
           type="email"
           required
           value={email}
           onChange={(event) => setEmail(event.target.value)}
           placeholder="you@organisation.com"
-          className={`h-12 flex-1 rounded-full border border-[color-mix(in_srgb,var(--brand-emerald)_25%,var(--brand-white))] bg-[var(--brand-white)] px-[var(--space-sm)] typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_75%,var(--emerald-canopy)_25%)] placeholder:text-[color-mix(in_srgb,var(--brand-emerald)_40%,var(--emerald-bough)_60%)] focus:border-[var(--brand-emerald)] focus:outline-none ${
-            isHorizontal ? '' : 'w-full'
-          }`}
           aria-label="Email address"
+          size="lg"
+          density="relaxed"
+          variant="default"
+          className={isHorizontal ? 'flex-1 rounded-full bg-[var(--brand-white)]' : 'w-full rounded-full bg-[var(--brand-white)]'}
         />
-        <button
+        <Button
           type="submit"
-          className="flex h-12 items-center justify-center rounded-full bg-[var(--brand-emerald)] px-[var(--space-md)] typography-body-sm font-semibold text-[var(--brand-white)] shadow-lg shadow-black/15 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)] whitespace-nowrap"
-          disabled={status === 'loading'}
+          shape="pill"
+          size="lg"
+          variant="primary"
+          className="whitespace-nowrap"
+          isLoading={status === 'loading'}
+          loadingText="Delivering…"
         >
-          {status === 'loading' ? 'Delivering…' : status === 'success' ? 'Briefing Sent!' : 'Send briefing PDF'}
-          <Send className="ml-[var(--space-2xs)] size-4" aria-hidden="true" />
-        </button>
+          {status === 'success' ? 'Briefing Sent!' : 'Send briefing PDF'}
+          {status !== 'loading' ? <Send className="size-4" aria-hidden="true" /> : null}
+        </Button>
       </form>
       {includeDownloadLink ? (
         <a

--- a/src/components/QuickGateways.jsx
+++ b/src/components/QuickGateways.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import { ShieldCheck, ServerCog, BarChart3 } from 'lucide-react'
 import { AccentPill } from '@/components/AccentPill.jsx'
+import { Card, CardDescription, CardTitle } from '@/components/ui/card.jsx'
 
 const gateways = [
   {
@@ -44,36 +45,43 @@ export default function QuickGateways() {
           {gateways.map(({ title, description, icon, to }) => {
             const IconComponent = icon
             return (
-              <Link
+              <Card
                 key={title}
-                to={to}
-                className="group flex flex-col justify-between rounded-2xl border border-[color-mix(in_srgb,var(--brand-emerald)_25%,var(--brand-white))] bg-[var(--brand-white)] p-[var(--space-lg)] shadow-lg shadow-black/5 transition hover:-translate-y-1 hover:border-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--emerald-ink)_30%)] hover:shadow-xl"
+                asChild
+                variant="surface"
+                padding="lg"
+                interactive
+                className="justify-between"
               >
-                <div className="flex size-12 items-center justify-center rounded-2xl bg-[color-mix(in_srgb,var(--brand-emerald)_12%,var(--brand-white)_88%)] text-[var(--brand-emerald)] shadow-md shadow-black/5 transition group-hover:bg-[var(--brand-emerald)] group-hover:text-[var(--brand-white)]">
-                  <IconComponent className="size-6" aria-hidden="true" />
-                </div>
-                <div>
-                  <h3 className="typography-heading-4 font-semibold text-[var(--brand-emerald)]">{title}</h3>
-                  <p className="mt-[var(--space-2xs)] typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_35%,var(--emerald-canopy)_65%)]">{description}</p>
-                </div>
-                <span className="inline-flex items-center justify-start typography-body-sm font-semibold text-[var(--brand-emerald)] transition group-hover:text-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--emerald-ink)_30%)]">
-                  Explore
-                  <svg
-                    className="ml-[var(--space-2xs)] size-4 transition group-hover:translate-x-1"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden="true"
-                  >
-                    <path d="M5 12h14" />
-                    <path d="m12 5 7 7-7 7" />
-                  </svg>
-                </span>
-              </Link>
+                <Link to={to} className="focus-visible:outline-none">
+                  <div className="flex size-12 items-center justify-center rounded-2xl bg-[color-mix(in_srgb,var(--brand-emerald)_12%,var(--brand-white)_88%)] text-[var(--brand-emerald)] shadow-md shadow-black/5 transition group-hover/card:bg-[var(--brand-emerald)] group-hover/card:text-[var(--brand-white)]">
+                    <IconComponent className="size-6" aria-hidden="true" />
+                  </div>
+                  <div className="flex flex-col gap-[var(--space-2xs)]">
+                    <CardTitle className="typography-heading-4 text-[var(--brand-emerald)]">{title}</CardTitle>
+                    <CardDescription className="typography-body-sm text-[color-mix(in_srgb,var(--brand-emerald)_35%,var(--emerald-canopy)_65%)]">
+                      {description}
+                    </CardDescription>
+                  </div>
+                  <span className="inline-flex items-center justify-start typography-body-sm font-semibold text-[var(--brand-emerald)] transition group-hover/card:text-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--emerald-ink)_30%)]">
+                    Explore
+                    <svg
+                      className="ml-[var(--space-2xs)] size-4 transition group-hover/card:translate-x-1"
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M5 12h14" />
+                      <path d="m12 5 7 7-7 7" />
+                    </svg>
+                  </span>
+                </Link>
+              </Card>
             )
           })}
         </div>

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -80,10 +80,13 @@ export default function Header() {
             <Link to="/funders#investor-deck">Investor Deck</Link>
           </Button>
         </div>
-        <button
+        <Button
           type="button"
           onClick={() => setOpen((prev) => !prev)}
-          className="rounded-md border border-[color-mix(in_srgb,var(--emerald-haze)_25%,var(--brand-white)_75%)] p-2 text-[var(--brand-emerald)] shadow-sm transition hover:border-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--emerald-ink)_30%)] hover:text-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--emerald-ink)_30%)] lg:hidden"
+          variant="outline"
+          size="icon"
+          shape="square"
+          className="border-[color-mix(in_srgb,var(--emerald-haze)_25%,var(--brand-white)_75%)] text-[var(--brand-emerald)] shadow-sm transition hover:border-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--emerald-ink)_30%)] hover:text-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--emerald-ink)_30%)] lg:hidden"
           aria-label="Toggle navigation"
           aria-expanded={open}
           aria-controls="mobile-navigation"
@@ -91,7 +94,7 @@ export default function Header() {
           ref={toggleRef}
         >
           {open ? <X className="size-5" /> : <Menu className="size-5" />}
-        </button>
+        </Button>
       </div>
       <div
         id="mobile-navigation"

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -1,55 +1,88 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { cva } from "class-variance-authority";
+import { Loader2 } from "lucide-react"
+import { cva } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap font-semibold tracking-tight transition-all focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[color-mix(in_srgb,var(--brand-emerald)_45%,var(--emerald-ink)_55%)]/35 disabled:pointer-events-none disabled:opacity-60 data-[state=loading]:pointer-events-none data-[state=loading]:opacity-90 [&_svg:not([data-no-shrink])]:shrink-0",
   {
     variants: {
       variant: {
-        default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
-        outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        primary:
+          "bg-[var(--brand-emerald)] text-[var(--brand-white)] shadow-lg shadow-[color-mix(in_srgb,var(--brand-emerald)_65%,var(--emerald-ink)_35%)]/30 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)] focus-visible:ring-[color-mix(in_srgb,var(--brand-emerald)_65%,var(--emerald-ink)_35%)]/40",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+          "bg-[color-mix(in_srgb,var(--brand-emerald)_12%,var(--brand-white)_88%)] text-[color-mix(in_srgb,var(--brand-emerald)_78%,var(--emerald-ink)_22%)] shadow-md shadow-black/10 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_18%,var(--brand-white)_82%)]",
+        outline:
+          "border border-[color-mix(in_srgb,var(--brand-emerald)_45%,var(--emerald-haze)_55%)] bg-white text-[color-mix(in_srgb,var(--brand-emerald)_75%,var(--emerald-ink)_25%)] shadow-sm shadow-black/5 hover:border-[color-mix(in_srgb,var(--brand-emerald)_75%,var(--emerald-ink)_25%)] hover:text-[color-mix(in_srgb,var(--brand-emerald)_85%,var(--emerald-ink)_15%)]",
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+          "bg-transparent text-[color-mix(in_srgb,var(--brand-emerald)_80%,var(--emerald-ink)_20%)] hover:bg-[color-mix(in_srgb,var(--brand-emerald)_8%,var(--brand-white)_92%)]",
+        link: "bg-transparent text-[var(--brand-emerald)] underline-offset-4 hover:text-[color-mix(in_srgb,var(--brand-emerald)_75%,var(--emerald-ink)_25%)] hover:underline",
+        subtle:
+          "bg-[color-mix(in_srgb,var(--brand-cream)_75%,var(--brand-white)_25%)] text-[color-mix(in_srgb,var(--brand-emerald)_72%,var(--emerald-ink)_28%)] shadow-sm shadow-black/10 hover:bg-[color-mix(in_srgb,var(--brand-cream)_65%,var(--brand-white)_35%)]",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
+        sm: "min-h-[40px] px-4 text-sm",
+        default: "min-h-[44px] px-5 text-sm",
+        lg: "min-h-[52px] px-6 text-base",
+        icon: "size-11",
+      },
+      shape: {
+        rounded: "rounded-xl",
+        pill: "rounded-full",
+        square: "rounded-md",
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: "primary",
       size: "default",
+      shape: "rounded",
     },
   }
 )
 
-function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ...props
-}) {
-  const Comp = asChild ? Slot : "button"
+const spinnerStyles = "size-4 animate-spin text-current"
 
-  return (
-    <Comp
-      data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
-      {...props} />
-  );
-}
+const Button = React.forwardRef(
+  (
+    {
+      className,
+      variant,
+      size,
+      shape,
+      asChild = false,
+      isLoading = false,
+      loadingText,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const Comp = asChild ? Slot : "button"
+    const { disabled, type, ...rest } = props
+    const mergedDisabled = isLoading ? true : disabled
+    const resolvedType = type ?? (asChild ? undefined : "button")
+    const content = isLoading ? loadingText ?? children : children
+
+    return (
+      <Comp
+        ref={asChild ? undefined : ref}
+        data-slot="button"
+        data-state={isLoading ? "loading" : undefined}
+        className={cn(buttonVariants({ variant, size, shape, className }))}
+        aria-busy={isLoading || undefined}
+        aria-disabled={asChild && mergedDisabled ? true : undefined}
+        {...(!asChild ? { disabled: mergedDisabled, type: resolvedType } : {})}
+        {...rest}
+      >
+        {isLoading && <Loader2 aria-hidden="true" className={spinnerStyles} />}
+        <span className="inline-flex items-center gap-2 leading-none">{content}</span>
+      </Comp>
+    )
+  }
+)
+
+Button.displayName = "Button"
 
 export { Button, buttonVariants }

--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -1,92 +1,122 @@
 import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva } from "class-variance-authority";
 
 import { cn } from "@/lib/utils"
 
+const cardVariants = cva(
+  "group/card relative flex flex-col gap-5 rounded-2xl border shadow-lg shadow-black/5 transition-shadow",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-[color-mix(in_srgb,var(--brand-emerald)_18%,var(--emerald-haze)_82%)] bg-[var(--brand-white)] text-[color-mix(in_srgb,var(--brand-emerald)_80%,var(--emerald-ink)_20%)]",
+        surface:
+          "border-[color-mix(in_srgb,var(--brand-emerald)_22%,var(--brand-white)_78%)] bg-[color-mix(in_srgb,var(--brand-white)_96%,var(--brand-cream)_4%)] text-[color-mix(in_srgb,var(--brand-emerald)_80%,var(--emerald-ink)_20%)]",
+        muted:
+          "border-[var(--brand-emerald)]/18 bg-[color-mix(in_srgb,var(--brand-cream)_72%,var(--brand-white)_28%)] text-[color-mix(in_srgb,var(--brand-emerald)_78%,var(--emerald-ink)_22%)]",
+        glass:
+          "border-white/25 bg-white/12 text-white backdrop-blur",
+        inverted:
+          "border-[color-mix(in_srgb,var(--emerald-ink)_70%,var(--brand-emerald)_30%)] bg-[color-mix(in_srgb,var(--emerald-ink)_92%,var(--brand-emerald)_8%)] text-white",
+      },
+      padding: {
+        none: "p-0",
+        sm: "p-4",
+        md: "p-6",
+        lg: "p-8",
+      },
+      interactive: {
+        false: "",
+        true: "transition-transform hover:-translate-y-1 hover:shadow-xl focus-within:-translate-y-1 focus-within:shadow-xl focus-within:ring-[3px] focus-within:ring-[color-mix(in_srgb,var(--brand-emerald)_45%,var(--emerald-ink)_55%)]/30",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      padding: "md",
+      interactive: false,
+    },
+  }
+)
+
 function Card({
   className,
+  variant,
+  padding,
+  interactive,
+  asChild = false,
   ...props
 }) {
+  const Comp = asChild ? Slot : "div"
+
   return (
-    <div
+    <Comp
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
-        className
+        "outline-none",
+        cardVariants({ variant, padding, interactive, className })
       )}
-      {...props} />
+      {...props}
+    />
   );
 }
 
-function CardHeader({
-  className,
-  ...props
-}) {
+function CardHeader({ className, ...props }) {
   return (
     <div
       data-slot="card-header"
       className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        "flex flex-col gap-2",
         className
       )}
-      {...props} />
+      {...props}
+    />
   );
 }
 
-function CardTitle({
-  className,
-  ...props
-}) {
+function CardTitle({ className, ...props }) {
   return (
     <div
       data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
-      {...props} />
+      className={cn("font-semibold leading-tight", className)}
+      {...props}
+    />
   );
 }
 
-function CardDescription({
-  className,
-  ...props
-}) {
+function CardDescription({ className, ...props }) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-muted-foreground text-sm", className)}
-      {...props} />
+      className={cn("text-sm text-[color-mix(in_srgb,var(--brand-emerald)_45%,var(--emerald-canopy)_55%)]", className)}
+      {...props}
+    />
   );
 }
 
-function CardAction({
-  className,
-  ...props
-}) {
+function CardAction({ className, ...props }) {
   return (
     <div
       data-slot="card-action"
-      className={cn(
-        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
-        className
-      )}
-      {...props} />
+      className={cn("col-start-2 row-span-2 row-start-1 self-start justify-self-end", className)}
+      {...props}
+    />
   );
 }
 
-function CardContent({
-  className,
-  ...props
-}) {
-  return (<div data-slot="card-content" className={cn("px-6", className)} {...props} />);
+function CardContent({ className, ...props }) {
+  return (
+    <div data-slot="card-content" className={cn("flex flex-col gap-4", className)} {...props} />
+  );
 }
 
-function CardFooter({
-  className,
-  ...props
-}) {
+function CardFooter({ className, ...props }) {
   return (
     <div
       data-slot="card-footer"
-      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
-      {...props} />
+      className={cn("flex items-center gap-3", className)}
+      {...props}
+    />
   );
 }
 

--- a/src/components/ui/input.jsx
+++ b/src/components/ui/input.jsx
@@ -1,24 +1,65 @@
 import * as React from "react"
+import { cva } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
-function Input({
-  className,
-  type,
-  ...props
-}) {
+const inputVariants = cva(
+  "flex w-full min-w-0 items-center border bg-white font-medium text-[color-mix(in_srgb,var(--brand-emerald)_72%,var(--emerald-ink)_28%)] placeholder:text-[color-mix(in_srgb,var(--brand-emerald)_45%,var(--emerald-haze)_55%)] transition-[border,box-shadow,background-color,color] focus-visible:outline-none focus-visible:border-[color-mix(in_srgb,var(--brand-emerald)_75%,var(--emerald-ink)_25%)] focus-visible:ring-[3px] focus-visible:ring-[color-mix(in_srgb,var(--brand-emerald)_45%,var(--emerald-ink)_55%)]/30 disabled:cursor-not-allowed disabled:opacity-60 aria-invalid:border-[color-mix(in_srgb,rgba(220,38,38,1)_70%,var(--brand-emerald)_30%)] aria-invalid:ring-[color-mix(in_srgb,rgba(220,38,38,1)_55%,var(--brand-emerald)_45%)]/30",
+  {
+    variants: {
+      variant: {
+        default: "border-[color-mix(in_srgb,var(--brand-emerald)_25%,var(--emerald-haze)_75%)] bg-[var(--brand-white)]",
+        subtle: "border-transparent bg-[color-mix(in_srgb,var(--brand-cream)_70%,var(--brand-white)_30%)] focus-visible:border-[color-mix(in_srgb,var(--brand-emerald)_35%,var(--emerald-ink)_65%)]",
+        inverted: "border-white/40 bg-white/10 text-white placeholder:text-white/60 focus-visible:border-white focus-visible:ring-white/40",
+      },
+      size: {
+        sm: "min-h-[40px] rounded-lg px-3 text-sm",
+        default: "min-h-[44px] rounded-xl px-4 text-sm",
+        lg: "min-h-[48px] rounded-2xl px-5 text-base",
+      },
+      density: {
+        relaxed: "py-3",
+        compact: "py-2",
+      },
+    },
+    compoundVariants: [
+      {
+        size: "sm",
+        density: "compact",
+        className: "py-2",
+      },
+      {
+        size: "default",
+        density: "compact",
+        className: "py-2.5",
+      },
+      {
+        size: "lg",
+        density: "relaxed",
+        className: "py-3.5",
+      },
+    ],
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+      density: "compact",
+    },
+  }
+)
+
+function Input({ className, type = "text", variant, size, density, ...props }, ref) {
   return (
     <input
+      ref={ref}
       type={type}
       data-slot="input"
-      className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-        className
-      )}
-      {...props} />
+      className={cn(inputVariants({ variant, size, density, className }))}
+      {...props}
+    />
   );
 }
 
-export { Input }
+const ForwardedInput = React.forwardRef(Input)
+ForwardedInput.displayName = "Input"
+
+export { ForwardedInput as Input, inputVariants }


### PR DESCRIPTION
## Summary
- replace the existing button, input, and card primitives with brand-aware variants that include loading, focus, and touch target affordances
- refactor newsletter signup, footer subscription, QuickGateways, and newsletter CTA sections to consume the new shared components
- update the mobile header toggle to rely on the shared button component for consistent focus and sizing

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_6902d073d374832b8e23535380c3a7bf