### PR TITLE
Improve responsive typography and mobile navigation

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -29,7 +29,7 @@ const handleHeroImageError = (event) => {
 
 export default function Hero() {
   return (
-    <section className="section-shell relative flex min-h-[85vh] items-center justify-start overflow-hidden" id="hero">
+    <section className="section-shell relative flex min-h-[70vh] items-center justify-start overflow-hidden sm:min-h-[85vh]" id="hero">
       <div className="absolute inset-0">
         <picture>
           <source type="image/jpeg" srcSet="/assets/branding/skooli_banner_image.jpg" sizes="100vw" />
@@ -50,17 +50,17 @@ export default function Hero() {
         />
       </div>
       <div className="relative z-10 section-container text-left text-[var(--brand-white)]">
-        <div className="max-w-2xl">
+        <div className="max-w-2xl space-y-[var(--space-md)] text-center sm:text-left">
           <AccentPill tone="inverse" size="sm" className="bg-[color-mix(in_srgb,var(--brand-white)_20%,transparent)]">
             Executive briefing
           </AccentPill>
-          <h1 className="mt-[var(--space-md)] typography-display font-semibold text-[var(--brand-white)]">
+          <h1 className="typography-display font-semibold text-[var(--brand-white)]">
             Operational assurance for national education pilots
           </h1>
-          <p className="mt-[var(--space-md)] typography-body-lg font-medium text-[color-mix(in_srgb,var(--brand-white)_90%,transparent)]">
+          <p className="typography-body-lg font-medium text-[color-mix(in_srgb,var(--brand-white)_90%,transparent)]">
             Skooli deploys accountable facilitators, verified suppliers, and transparent financial rails so ministries see auditable results from the first cohort through national scale.
           </p>
-          <div className="mt-[var(--space-xl)]">
+          <div className="pt-[var(--space-md)]">
             <Button
               size="lg"
               className="rounded-md bg-[var(--brand-emerald)] px-[var(--space-xl)] py-[var(--space-sm)] text-base font-semibold text-[var(--brand-white)] shadow-lg shadow-black/10 transition hover:-translate-y-0.5 hover:bg-[color-mix(in_srgb,var(--brand-emerald)_80%,var(--emerald-ink)_20%)]"

--- a/src/components/HeroStats.jsx
+++ b/src/components/HeroStats.jsx
@@ -7,7 +7,7 @@ export default function HeroStats() {
   return (
     <section className="section-shell bg-transparent" data-spacing="tight">
       <div className="section-container max-w-6xl">
-        <div className="grid gap-[var(--space-md)] rounded-2xl bg-[color-mix(in_srgb,var(--brand-white)_95%,transparent)] p-[var(--space-md)] shadow-xl shadow-black/5 backdrop-blur sm:grid-cols-3">
+        <div className="grid gap-[var(--space-md)] rounded-2xl bg-[color-mix(in_srgb,var(--brand-white)_95%,transparent)] p-[var(--space-md)] shadow-xl shadow-black/5 backdrop-blur sm:grid-cols-2 lg:grid-cols-3">
           {items.map((item) => (
             <div key={item.label} className="flex items-center justify-center rounded-xl p-[var(--space-md)] text-center">
               <div>

--- a/src/components/HowItWorksPreview.jsx
+++ b/src/components/HowItWorksPreview.jsx
@@ -38,13 +38,13 @@ export default function HowItWorksPreview() {
             Explore the full playbook →
           </Link>
         </div>
-        <div className="mt-12 grid gap-6 md:grid-cols-3">
+        <div className="mt-12 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {steps.map(({ title, description, icon }, index) => {
             const StepIcon = icon
             return (
               <div
                 key={title}
-                className="rounded-2xl bg-[var(--brand-cream)] p-8 shadow-lg shadow-black/5 transition hover:-translate-y-1 hover:shadow-xl"
+                className="rounded-2xl bg-[var(--brand-cream)] p-6 shadow-lg shadow-black/5 transition hover:-translate-y-1 hover:shadow-xl sm:p-8"
               >
                 <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-[var(--brand-white)] text-[var(--brand-emerald)] shadow-md">
                   <StepIcon className="size-6" aria-hidden="true" />

--- a/src/components/ImpactSnapshot.jsx
+++ b/src/components/ImpactSnapshot.jsx
@@ -34,7 +34,7 @@ export default function ImpactSnapshot() {
   return (
     <section className="bg-gradient-to-br from-[var(--brand-emerald)] to-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--neutral-black)_30%)] py-16 text-[var(--brand-white)]" id="impact">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="flex flex-col gap-8 md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-col gap-8 md:flex-row md:items-start md:justify-between">
           <div>
             <AccentPill tone="inverse" size="sm" className="bg-[var(--brand-white)]/25">
               Executive Dashboard Sync
@@ -70,7 +70,7 @@ export default function ImpactSnapshot() {
             <p className="typography-heading-3 font-semibold">29 Jan 2025 • 14:00 EAT</p>
           </div>
         </div>
-        <div className="mt-12 grid gap-6 sm:grid-cols-3" ref={ref}>
+        <div className="mt-12 grid gap-6 md:grid-cols-2 xl:grid-cols-3" ref={ref}>
           {stats.map(({ label, value, suffix, format }) => {
             const displayValue = visible
               ? format

--- a/src/components/NewsletterCTA.jsx
+++ b/src/components/NewsletterCTA.jsx
@@ -6,7 +6,7 @@ export default function NewsletterCTA() {
   return (
     <section className="bg-white py-16" id="newsletter">
       <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-        <div className="rounded-3xl bg-gradient-to-br from-[var(--brand-white)] via-[var(--brand-cream)] to-[color-mix(in_srgb,var(--brand-emerald)_12%,var(--brand-white)_88%)] p-10 shadow-xl shadow-black/10 sm:p-16">
+        <div className="rounded-3xl bg-gradient-to-br from-[var(--brand-white)] via-[var(--brand-cream)] to-[color-mix(in_srgb,var(--brand-emerald)_12%,var(--brand-white)_88%)] p-8 shadow-xl shadow-black/10 sm:p-12 lg:p-16">
           <div className="flex flex-col gap-8">
             <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
               <div className="max-w-2xl">
@@ -23,7 +23,7 @@ export default function NewsletterCTA() {
                   Subscribe for Mailchimp briefings on impact milestones, product launches, and treasury notes. Every confirmation email now includes the latest PDF dashboard sync for your leadership team.
                 </p>
               </div>
-              <NewsletterSignupModule layout="horizontal" includeDownloadLink className="flex flex-col items-start gap-4" />
+              <NewsletterSignupModule layout="horizontal" includeDownloadLink className="flex flex-col items-start gap-4 lg:items-end" />
             </div>
 
             <Card
@@ -45,7 +45,7 @@ export default function NewsletterCTA() {
                 </span>
               </CardHeader>
               <CardContent className="gap-6 p-0">
-                <div className="grid gap-4 sm:grid-cols-3">
+                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
                   {impactInsights.map((item) => (
                     <Card
                       key={item.label}

--- a/src/components/NewsletterSignupModule.jsx
+++ b/src/components/NewsletterSignupModule.jsx
@@ -22,7 +22,7 @@ export function NewsletterSignupModule({ layout = 'horizontal', includeDownloadL
 
   const isHorizontal = layout === 'horizontal'
   const formClasses = isHorizontal
-    ? 'flex w-full max-w-md flex-col gap-[var(--space-xs)] sm:flex-row'
+    ? 'flex w-full max-w-md flex-col gap-[var(--space-xs)] md:flex-row'
     : 'flex w-full flex-col gap-[var(--space-xs)]'
 
   return (

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
 import { Link, NavLink } from 'react-router-dom'
-import { Menu, X } from 'lucide-react'
 import { Button } from '@/components/ui/button.jsx'
 
 const primaryNavItems = [
@@ -19,6 +18,7 @@ export default function Header() {
   const [open, setOpen] = useState(false)
   const toggleRef = useRef(null)
   const firstNavLinkRef = useRef(null)
+  const bodyLockRef = useRef(false)
 
   useEffect(() => {
     if (open && firstNavLinkRef.current) {
@@ -43,6 +43,24 @@ export default function Header() {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [open])
 
+  useEffect(() => {
+    const body = document.body
+    if (open) {
+      bodyLockRef.current = !body.classList.contains('overflow-hidden')
+      body.classList.add('overflow-hidden')
+    } else if (bodyLockRef.current) {
+      body.classList.remove('overflow-hidden')
+      bodyLockRef.current = false
+    }
+
+    return () => {
+      if (bodyLockRef.current) {
+        body.classList.remove('overflow-hidden')
+        bodyLockRef.current = false
+      }
+    }
+  }, [open])
+
   const closeMenu = () => {
     setOpen(false)
     toggleRef.current?.focus()
@@ -50,7 +68,7 @@ export default function Header() {
 
   return (
     <header className="sticky top-0 z-50 border-b border-[color-mix(in_srgb,var(--emerald-haze)_25%,var(--brand-white)_75%)] bg-white/95 backdrop-blur">
-      <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3 sm:px-6 lg:py-4 lg:px-8">
         <Link to="/" className="flex items-center gap-2 text-[var(--brand-emerald)]">
           <span className="text-2xl font-bold tracking-tight">Skooli</span>
         </Link>
@@ -86,22 +104,47 @@ export default function Header() {
           variant="outline"
           size="icon"
           shape="square"
-          className="border-[color-mix(in_srgb,var(--emerald-haze)_25%,var(--brand-white)_75%)] text-[var(--brand-emerald)] shadow-sm transition hover:border-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--emerald-ink)_30%)] hover:text-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--emerald-ink)_30%)] lg:hidden"
+          className={`border-[color-mix(in_srgb,var(--emerald-haze)_25%,var(--brand-white)_75%)] text-[var(--brand-emerald)] shadow-sm transition hover:border-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--emerald-ink)_30%)] hover:text-[color-mix(in_srgb,var(--brand-emerald)_70%,var(--emerald-ink)_30%)] lg:hidden ${
+            open ? 'bg-[color-mix(in_srgb,var(--brand-emerald)_8%,var(--brand-white)_92%)]' : ''
+          }`}
           aria-label="Toggle navigation"
           aria-expanded={open}
           aria-controls="mobile-navigation"
           aria-haspopup="true"
           ref={toggleRef}
         >
-          {open ? <X className="size-5" /> : <Menu className="size-5" />}
+          <span className="relative block h-5 w-6" aria-hidden="true">
+            <span
+              className={`absolute left-0 h-0.5 w-full rounded-full bg-current transition-transform duration-300 ease-out ${
+                open ? 'top-1/2 -translate-y-1/2 rotate-45' : 'top-0'
+              }`}
+            />
+            <span
+              className={`absolute left-0 top-1/2 h-0.5 w-full -translate-y-1/2 rounded-full bg-current transition-all duration-200 ease-out ${
+                open ? 'opacity-0' : 'opacity-100'
+              }`}
+            />
+            <span
+              className={`absolute left-0 h-0.5 w-full rounded-full bg-current transition-transform duration-300 ease-out ${
+                open ? 'bottom-1/2 translate-y-1/2 -rotate-45' : 'bottom-0'
+              }`}
+            />
+          </span>
         </Button>
       </div>
       <div
         id="mobile-navigation"
-        className="border-t border-[color-mix(in_srgb,var(--emerald-haze)_25%,var(--brand-white)_75%)] bg-white/95 shadow-lg shadow-black/5 lg:hidden"
-        hidden={!open}
+        className={`origin-top overflow-hidden border-t border-[color-mix(in_srgb,var(--emerald-haze)_25%,var(--brand-white)_75%)] bg-white/95 shadow-lg shadow-black/5 transition-[max-height,opacity,transform] duration-300 ease-out lg:hidden ${
+          open ? 'max-h-[32rem] scale-y-100 opacity-100' : 'pointer-events-none max-h-0 scale-y-95 opacity-0'
+        }`}
+        aria-hidden={!open}
       >
-        <nav aria-label="Mobile" className="mx-auto flex max-w-7xl flex-col gap-1 px-4 py-4">
+        <nav
+          aria-label="Mobile"
+          className={`mx-auto flex max-w-7xl flex-col gap-1 px-4 py-4 transition-transform duration-300 ease-out ${
+            open ? 'translate-y-0' : '-translate-y-2'
+          }`}
+        >
           {primaryNavItems.map(({ name, to }) => (
             <NavLink
               key={to}

--- a/src/index.css
+++ b/src/index.css
@@ -93,7 +93,6 @@
   --sidebar-accent-foreground: var(--brand-white);
   --sidebar-border: color-mix(in srgb, var(--brand-emerald) 20%, var(--brand-white));
   --sidebar-ring: color-mix(in srgb, var(--brand-emerald) 65%, var(--emerald-canopy));
-  --section-max-width: 80rem;
 }
 
 .dark {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -2,15 +2,15 @@
   /* Typography */
   --font-family-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 
-  --font-size-display: clamp(2.75rem, 1.25rem + 4vw, 4rem);
-  --font-size-h1: clamp(2.25rem, 1.1rem + 2.5vw, 3.25rem);
-  --font-size-h2: clamp(2rem, 1rem + 2vw, 2.75rem);
-  --font-size-h3: clamp(1.75rem, 0.9rem + 1.5vw, 2.25rem);
-  --font-size-h4: clamp(1.5rem, 0.75rem + 1.2vw, 1.75rem);
-  --font-size-body-lg: 1.25rem;
-  --font-size-body-md: 1rem;
-  --font-size-body-sm: 0.875rem;
-  --font-size-body-xs: 0.75rem;
+  --font-size-display: clamp(2.1rem, 1.3rem + 3vw, 3.75rem);
+  --font-size-h1: clamp(1.8rem, 1.1rem + 2.5vw, 3rem);
+  --font-size-h2: clamp(1.6rem, 1rem + 2vw, 2.5rem);
+  --font-size-h3: clamp(1.4rem, 0.9rem + 1.5vw, 2rem);
+  --font-size-h4: clamp(1.25rem, 0.85rem + 1vw, 1.6rem);
+  --font-size-body-lg: clamp(1.05rem, 0.95rem + 0.8vw, 1.25rem);
+  --font-size-body-md: clamp(0.95rem, 0.9rem + 0.45vw, 1.1rem);
+  --font-size-body-sm: clamp(0.85rem, 0.8rem + 0.3vw, 0.95rem);
+  --font-size-body-xs: clamp(0.75rem, 0.7rem + 0.2vw, 0.85rem);
 
   --line-height-tight: 1.1;
   --line-height-snug: 1.25;
@@ -47,9 +47,10 @@
   --space-5xl: 6rem;
 
   /* Section layout */
-  --space-section-inline: clamp(var(--space-sm), 4vw, var(--space-xl));
-  --space-section-y: clamp(var(--space-3xl), 6vw, var(--space-5xl));
+  --space-section-inline: clamp(var(--space-sm), 6vw, var(--space-xl));
+  --space-section-y: clamp(var(--space-xl), 8vw, var(--space-5xl));
   --space-section-tight-y: calc(var(--space-section-y) * 0.6);
+  --section-max-width: clamp(22rem, 90vw, 80rem);
 }
 
 body {
@@ -114,4 +115,28 @@ p,
 .body-xs {
   font-size: var(--font-size-body-xs);
   line-height: var(--line-height-relaxed);
+}
+
+@media (max-width: 40rem) {
+  :root {
+    --space-section-inline: clamp(var(--space-2xs), 7vw, var(--space-md));
+    --space-section-y: clamp(var(--space-lg), 12vw, var(--space-3xl));
+  }
+
+  .section-shell[data-spacing='tight'] {
+    padding-block: clamp(var(--space-md), 10vw, var(--space-xl));
+  }
+}
+
+@media (min-width: 64rem) {
+  :root {
+    --space-section-inline: clamp(var(--space-md), 4vw, var(--space-2xl));
+  }
+}
+
+@media (min-width: 90rem) {
+  :root {
+    --section-max-width: 90rem;
+    --space-section-inline: clamp(var(--space-lg), 3vw, var(--space-3xl));
+  }
 }


### PR DESCRIPTION
## Summary
- tune the shared typography and spacing tokens so sections scale cleanly from small screens through large desktops
- refine hero, stats, and CTA sections with tablet-friendly two-column grids and mobile-first spacing adjustments
- animate the hamburger trigger, add a sliding mobile menu, and lock body scrolling while the drawer is open

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_6902d7ac405c832bbfb11681ac1ac314